### PR TITLE
Handle IOError when file can't be opened

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -330,7 +330,10 @@ def main(options, arguments):
     Error.options = options
     errors = []
     for filename in arguments:
-        errors.extend(check_source(open(filename).read(), filename))
+        try:
+            errors.extend(check_source(open(filename).read(), filename))
+        except IOError:
+            print "Error opening file %s" % filename
     for error in sorted(errors):
         print(error)
 


### PR DESCRIPTION
If a filename given on the command line does not exist,
or for some reason can't be opened, an IOError will be
raised when trying to open it.
