### PR TITLE
Speed improvements

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -202,10 +202,12 @@ def parse_top_level(source, keyword):
         yield source[abs_pos(start, source): abs_pos(end, source)]
 
 
+@cached
 def parse_functions(source):
     return parse_top_level(source, 'def')
 
 
+@cached
 def parse_classes(source):
     return parse_top_level(source, 'class')
 


### PR DESCRIPTION
More than quadruples-ish (~4x) the speed of `pep257`. I've been looking into speeding it up even further, but that would require slightly bigger refactorings to be able to reuse the results from `StringIO.readline` (cumtime: 2.22 seconds) and `StringIO.readlines` (cumtime: 3.48 seconds).

This fix is related to issue #9.
