### PR TITLE
Revert "Remove unnecessary PEP references"

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -395,7 +395,7 @@ def main(options, arguments):
 
 
 def check_modules_have_docstrings(module_docstring, context, is_script):
-    """Modules should have docstrings.
+    """All modules should have docstrings.
 
     All modules should normally have docstrings.
 
@@ -481,7 +481,7 @@ def check_unicode_docstring(docstring, context, is_script):
 
 
 def check_one_liners(docstring, context, is_script):
-    """One-liners should fit on one line with quotes.
+    """One-liner docstrings should fit on one line with quotes.
 
     The closing quotes are on the same line as the opening quotes.
     This looks better for one-liners.
@@ -584,7 +584,7 @@ def check_blank_after_summary(docstring, context, is_script):
 
 
 def check_indent(docstring, context, is_script):
-    """Docstrings should be indented same as code.
+    """The entire docstring should be indented same as code.
 
     The entire docstring is indented the same as the quotes at its
     first line.


### PR DESCRIPTION
This reverts commit fa96c4f5d54d0628a492413d44edcd37923f62c2.

Removing these references causes the docstrings to not pass
the PEP-257 check when pep257.py is run on itself.

Fixes #25

Change-Id: I70471d2b120d93895fad61fca8bd8627d9012f19
