### PR TITLE
Print error messages to stderr

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -55,10 +55,11 @@ Also, see examples in "Check functions" section.
 
 """
 
-import re
-import inspect
 from curses.ascii import isascii
+import inspect
 from optparse import OptionParser
+import re
+import sys
 import tokenize as tk
 
 
@@ -359,6 +360,12 @@ def parse_options():
     return parser.parse_args()
 
 
+def print_error(message):
+    sys.stderr.write(message)
+    sys.stderr.write('\n')
+    sys.stderr.flush()
+
+
 def main(options, arguments):
     print('=' * 80)
     print('Note: checks are relaxed for scripts (with #!) compared to modules')
@@ -370,16 +377,16 @@ def main(options, arguments):
         try:
             f = open(filename)
         except IOError:
-            print("Error opening file %s" % filename)
+            print_error("Error opening file %s" % filename)
         else:
             try:
                 errors.extend(check_source(f.read(), filename))
             except IOError:
-                print("Error reading file %s" % filename)
+                print_error("Error reading file %s" % filename)
             finally:
                 f.close()
     for error in sorted(errors):
-        print(error)
+        print_error(str(error))
 
 
 #


### PR DESCRIPTION
Update the output of error messages so that the messages go
to stderr instead of stdout.

Also reorder the imports into alphabetical order.

Fixes #26

Change-Id: Ib3eae2b70254787fd06d2f9997bc98feb65958d8
