### PR TITLE
Add verbose mode

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -356,12 +356,16 @@ def parse_options():
                       help='show error start..end positions')
     parser.add_option('-q', '--quote', action='store_true',
                       help='quote erroneous lines')
+    parser.add_option('-v', '--verbose', action='store_true',
+                      help='enable verbose mode')
     return parser.parse_args()
 
 
 def main(options, arguments):
-    print('=' * 80)
-    print('Note: checks are relaxed for scripts (with #!) compared to modules')
+    if options.verbose:
+        print('=' * 80)
+        print('Note: checks are relaxed for scripts (with #!) '
+              'compared to modules')
     Error.explain = options.explain
     Error.range = options.range
     Error.quote = options.quote


### PR DESCRIPTION
Add a new option -v/--verbose.  Only display the introductory
note and ==== header when this option is enabled.

Fixes #27

Change-Id: Ia5a5a5eecb811263c08b548524ef5347de4490d7
