### PR TITLE
Recursively process files from subdirectories

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -58,6 +58,7 @@ Also, see examples in "Check functions" section.
 from curses.ascii import isascii
 import inspect
 from optparse import OptionParser
+import os
 import re
 import sys
 import tokenize as tk
@@ -373,7 +374,19 @@ def main(options, arguments):
     Error.range = options.range
     Error.quote = options.quote
     errors = []
-    for filename in arguments:
+    input_files = []
+
+    for arg in arguments:
+        if os.path.isdir(arg):
+            for root, _dirs, files in os.walk(arg):
+                input_files += [os.path.join(root, f) for f in sorted(files)
+                                if f.endswith(".py")]
+        elif os.path.isfile(arg):
+            input_files += [arg]
+        else:
+            print_error("%s is not a file or directory" % arg)
+
+    for filename in input_files:
         try:
             f = open(filename)
         except IOError:


### PR DESCRIPTION
Currently the script only supports passing a subdirectory as
argument if it also includes some kind of file spec, for example:

  ./pep257.py folder1/file2.py folder2/*.py

This change adds support for passing directory names as arguments
without file spec:

 ./pep257.py file1.py folder

All .py files under the directory will be processed.  Files within
subdirectories will also be processed recursively.

Change-Id: I06befd6a1d2d8de37696e6a9a95a7229a28f3c80
