### PR TITLE
More updates

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -412,6 +412,8 @@ def main(options, arguments):
                 errors.extend(check_source(f.read(), filename))
             except IOError:
                 print_error("Error reading file %s" % filename)
+            except tk.TokenError:
+                print_error("Error parsing file %s" % filename)
             finally:
                 f.close()
     for error in sorted(errors):


### PR DESCRIPTION
A few more tweaks and improvements to the handling of files in subfolders.
- Files checked with the check_files method can also be treated as subfolders, and files within them will be recursively added, same as if a folder name is passed on the command line.
- Files beginning with "test_" are properly handled when found in subfolders.
- Filenames are displayed with their full absolute path in the error output.

EDIT:  Also added:
- Token errors (i.e. caused by running on a non-python file) are handled gracefully
