### PR TITLE
Fix duplicate reporting of docstring errors

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -167,8 +167,11 @@ def parse_module_docstring(source):
 
 def parse_docstring(source, what=''):
     """Parse docstring given `def` or `class` source."""
+    module_docstring = parse_module_docstring(source)
     if what.startswith('module'):
-        return parse_module_docstring(source)
+        return module_docstring
+    if module_docstring:
+        return module_docstring
     token_gen = tk.generate_tokens(StringIO(source).readline)
     try:
         kind = None
@@ -249,7 +252,7 @@ def parse_contexts(source, kind):
     if kind == 'def_docstring':
         return parse_functions(source) + parse_methods(source)
     if kind == 'docstring':
-        return ([source] + parse_functions(source) +
+        return ([parse_module_docstring(source)] + parse_functions(source) +
                 parse_classes(source) + parse_methods(source))
 
 


### PR DESCRIPTION
If there is an error in the docstring of the class or def that
appears first in the module, the error is reported twice by pep257.

When checking for 'docstring' related checks, the 'parse_docstring'
method was returning the docstring of the class or def that appears
first in the module, instead of the module's docstring.

Fixes #18

Change-Id: I38582f0369592c5c44db50ea4815f2f44cdedd81
Signed-off-by: David Pursehouse david.pursehouse@sonymobile.com
