### PR TITLE
Exit with error status when PEP257 violations are found

### DIFF
--- a/pep257
+++ b/pep257
@@ -1,9 +1,10 @@
 #! /usr/bin/env python
+import sys
 from pep257 import main, parse_options
 
 
 if __name__ == '__main__':
     try:
-        main(*parse_options())
+        sys.exit(main(*parse_options()))
     except KeyboardInterrupt:
         pass

--- a/pep257.py
+++ b/pep257.py
@@ -418,6 +418,7 @@ def main(options, arguments):
                 f.close()
     for error in sorted(errors):
         print_error(str(error))
+    return 1 if errors else 0
 
 
 #
@@ -671,6 +672,6 @@ def check_blank_after_last_paragraph(docstring, context, is_script):
 
 if __name__ == '__main__':
     try:
-        main(*parse_options())
+        sys.exit(main(*parse_options()))
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
The pep257.py script currently always exits with status code 0 whether
or not there are PEP-257 violations in the input file(s).  This makes
it difficult to use in automated checks that rely on the exit status,
such as running the script in Jenkins jobs triggered from Gerrit.

Update the script to exit with an error code when there are errors.

The error code is the count of errors found, which will be 0 (success)
when no errors are found.

Change-Id: I4fd7b0c80cebfea5d8daf353dba9d1ee440b041f
Signed-off-by: David Pursehouse david.pursehouse@sonymobile.com
