### PR TITLE
Handle non unique docstring.

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -645,7 +645,7 @@ def check_blank_before_after_class(class_docstring, context, is_script):
     """
     if not class_docstring:
         return
-    before, after = context.split(class_docstring)
+    before, after = context.split(class_docstring)[:2]
     before_blanks = [not line.strip() for line in before.split('\n')]
     after_blanks = [not line.strip() for line in after.split('\n')]
     if before_blanks[-3:] != [False, True, True]:

--- a/test_pep257.py
+++ b/test_pep257.py
@@ -158,6 +158,17 @@ def test_check_blank_before_after_class():
 '''
     assert not check('"""This should work."""', c5, False)
 
+    c6 = '''class Perfect(object):
+
+    """This should work perfectly."""
+
+    def foo(self):
+        """This should work perfectly."""
+        pass
+
+    '''
+    assert not check('"""This should work perfectly."""', c6, False)
+
 
 def test_check_blank_after_summary():
     check = pep257.check_blank_after_summary


### PR DESCRIPTION
When a class docstring and the docstring of a method in this class are
the same, pep257 should not raise an exception.
