### PR TITLE
Support for __all__ as a list with square brackets

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -220,13 +220,24 @@ class Parser(object):
         if self.current.value != '=':
             raise AllError('Could not evaluate contents of __all__. ')
         self.consume(tk.OP)
-        if self.current.value != '(':
+        if self.current.value not in '([':
             raise AllError('Could not evaluate contents of __all__. ')
+        if self.current.value == '[':
+            msg = ("%s WARNING: __all__ is defined as a list, this means "
+                   "pep257 cannot reliably detect contents of the __all__ "
+                   "variable, because it can be mutated. Change __all__ to be "
+                   "an (immutable) tuple, to remove this warning. Note, "
+                   "pep257 uses __all__ to detect which definitions are "
+                   "public, to warn if public definitions are missing "
+                   "docstrings. If __all__ is a (mutable) list, pep257 cannot "
+                   "reliably assume its contents. pep257 will proceed "
+                   "assuming __all__ is not mutated.\n" % self.filename)
+            sys.stderr.write(msg)
         self.consume(tk.OP)
         s = '('
         if self.current.kind != tk.STRING:
             raise AllError('Could not evaluate contents of __all__. ')
-        while self.current.value != ')':
+        while self.current.value not in ')]':
             s += self.current.value
             self.stream.move()
         s += ')'

--- a/test_definitions.py
+++ b/test_definitions.py
@@ -25,6 +25,10 @@ class class_(object):
         def nested_3(self):
             """Nested."""
 '''
+source_alt = '''
+__all__ = ['a', 'b'
+           'c',]
+'''
 
 
 def test_parser():
@@ -54,6 +58,10 @@ def test_parser():
                           '"""Nested."""', _, method_2) == nested_3
     assert nested_3.module == module
     assert nested_3.all == all
+
+    module = parse(StringIO(source_alt), 'file_alt.py')
+    assert Module('file_alt.py', _, 1, len(source_alt.split('\n')),
+                  None, _, _, all) == module
 
 
 def _test_module():


### PR DESCRIPTION
__all__ can be a list. This adds a failing test
for that and fixes it.
