### PR TITLE
Allow for greater flexibility in parsing __all__.

### DIFF
--- a/pep257.py
+++ b/pep257.py
@@ -235,6 +235,8 @@ class Parser(object):
             sys.stderr.write(msg)
         self.consume(tk.OP)
         s = '('
+        while self.current.kind in (tk.NL, tk.COMMENT):
+            self.stream.move()
         if self.current.kind != tk.STRING:
             raise AllError('Could not evaluate contents of __all__. ')
         while self.current.value not in ')]':

--- a/test_definitions.py
+++ b/test_definitions.py
@@ -29,6 +29,12 @@ source_alt = '''
 __all__ = ['a', 'b'
            'c',]
 '''
+source_alt_nl_at_bracket = '''
+__all__ = [
+
+    # Inconvenient comment.
+    'a', 'b' 'c',]
+'''
 
 
 def test_parser():
@@ -62,6 +68,11 @@ def test_parser():
     module = parse(StringIO(source_alt), 'file_alt.py')
     assert Module('file_alt.py', _, 1, len(source_alt.split('\n')),
                   None, _, _, all) == module
+
+    module = parse(StringIO(source_alt_nl_at_bracket), 'file_alt_nl.py')
+    assert Module('file_alt_nl.py', _, 1,
+                  len(source_alt_nl_at_bracket.split('\n')), None, _, _,
+                  all) == module
 
 
 def _test_module():


### PR DESCRIPTION
This patch allows for newlines and comments to be inserted between the opening
parenthesis or bracket for the **all** list and the first string value.
Additionally, a test has been added for this case.

Proposed to fix #66.
