### PR TITLE
Fix tests

### DIFF
--- a/test.py
+++ b/test.py
@@ -216,14 +216,4 @@ def old_209():
 
     """
 
-
-def run():
-    """Run the functions above and check errors agains expected errors."""
-    import pep257
-    expect(__file__, 'D100: Docstring missing')
-    results = list(pep257.check([__file__]))
-    assert set(map(type, results)) == set([pep257.Error]), results
-    results = set([(e.definition.name, e.message) for e in results])
-    print('\n  extra: %r' % (results - expected))
-    print('\nmissing: %r' % (expected - results))
-    assert expected == results
+expect('test.py', 'D100: Docstring missing')

--- a/test_definitions.py
+++ b/test_definitions.py
@@ -1,4 +1,4 @@
-from pep257 import (StringIO, TokenStream, Parser,
+from pep257 import (StringIO, TokenStream, Parser, Error, check,
                     Module, Class, Method, Function, NestedFunction)
 
 
@@ -91,10 +91,6 @@ def _test_module():
     assert function.name == 'function'
     assert function.docstring == '"""Function docstring."""'
 
-    #nested_function, = function.children
-    #assert nested_function.source.startswith('def nested_function')
-    #assert nested_function.source.endswith('pass\n')
-
 
 def test_token_stream():
     stream = TokenStream(StringIO('hello#world'))
@@ -108,4 +104,9 @@ def test_token_stream():
 def test_pep257():
     """Run domain-specific tests from test.py file."""
     import test
-    test.run()
+    results = list(check(['test.py']))
+    assert set(map(type, results)) == set([Error]), results
+    results = set([(e.definition.name, e.message) for e in results])
+    print('\nextra: %r' % (results - test.expected))
+    print('\nmissing: %r' % (test.expected - results))
+    assert test.expected == results


### PR DESCRIPTION
Test worked on first run and failed on the second run.
The reason for this is the reference to `__file__` in `test.py`.
The problem is that after the first run, `__file__` points to the `.pyc` file instead of the original `.py` file which makes `pep257` fail (because it requires the source).
