### PR TITLE
Add --format.

### DIFF
--- a/docs/snippets/cli.rst
+++ b/docs/snippets/cli.rst
@@ -10,6 +10,8 @@ Usage
     -h, --help            show this help message and exit
     -e, --explain         show explanation of each error
     -s, --source          show source for each error
+    --format=<format>     override default error format (ignores --explain and
+                            --source)
     --ignore=<codes>      ignore a list comma-separated error codes, for
                             example: --ignore=D101,D202
     --match=<pattern>     check only files that exactly match <pattern> regular
@@ -23,4 +25,3 @@ Usage
     -d, --debug           print debug information
     -v, --verbose         print status information
     --count               print total number of errors to stdout
-

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -12,6 +12,12 @@ Command Line Interface
 
 .. include:: snippets/cli.rst
 
+``--format`` supports the following keywords for replacement: ``filename``,
+``line``, ``definition``, ``message``, ``explanation``, and ``lines``. For
+example:
+
+.. code::
+    %(filename)s:%(line)3d: %(definition)s: %(message)s
 
 Configuration Files
 ^^^^^^^^^^^^^^^^^^^

--- a/pep257.py
+++ b/pep257.py
@@ -495,7 +495,8 @@ class Error(object):
         self.explanation = '\n'.join(l for l in self.explanation.split('\n')
                                      if not is_blank(l))
         if not Error.fmt:
-            template = '%(filename)s:%(line)s %(definition)s:\n        %(message)s'
+            template = ('%(filename)s:%(line)s %(definition)s:\n'
+                        '        %(message)s')
             if self.source and self.explain:
                 template += '\n\n%(explanation)s\n\n%(lines)s\n'
             elif self.source and not self.explain:


### PR DESCRIPTION
Quite simple, but gives pep257 some of the flexibility of other linters (eg pylint & pep8).

I couldn't figure out how to build the docs, so I couldn't check if my docs contribution works as expected. You might need to fix it -- sorry!