### PR TITLE
Consider uppercase docstring prefixes at D300.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,12 @@ Release Notes
 **pydocstyle** version numbers follow the
 `Semantic Versioning <http://semver.org/>`_ specification.
 
+x.x.x - Current Development Version
+-----------------------------------
+
+* The error code D300 is now also being reported if a docstring has
+  uppercase literals (``R`` or ``U``) as prefix (#176).
+
 1.0.0 - January 30th, 2016
 --------------------------
 

--- a/src/pydocstyle.py
+++ b/src/pydocstyle.py
@@ -1554,15 +1554,17 @@ class PEP257Checker(object):
               """ quotes in its body.
 
         '''
-        if (docstring and '"""' in ast.literal_eval(docstring) and
-                docstring.startswith(("'''", "r'''", "u'''", "ur'''"))):
-            # Allow ''' quotes if docstring contains """, because otherwise """
-            # quotes could not be expressed inside docstring.  Not in PEP 257.
-            return
-        if docstring and not docstring.startswith(
-                ('"""', 'r"""', 'u"""', 'ur"""')):
-            quotes = "'''" if "'''" in docstring[:4] else "'"
-            return D300(quotes)
+        if docstring:
+            opening = docstring[:5].lower()
+            if '"""' in ast.literal_eval(docstring) and opening.startswith(
+                    ("'''", "r'''", "u'''", "ur'''")):
+                # Allow ''' quotes if docstring contains """, because
+                # otherwise """ quotes could not be expressed inside
+                # docstring. Not in PEP 257.
+                return
+            if not opening.startswith(('"""', 'r"""', 'u"""', 'ur"""')):
+                quotes = "'''" if "'''" in opening else "'"
+                return D300(quotes)
 
     @check_for(Definition)
     def check_backslashes(self, definition, docstring):

--- a/src/tests/test_cases/test.py
+++ b/src/tests/test_cases/test.py
@@ -218,23 +218,44 @@ def multiline():
 
 
 @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
-def lsfklkjllkjl():
+def triple_single_quotes_raw():
     r'''Summary.'''
 
 
+@expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+def triple_single_quotes_raw_uppercase():
+    R'''Summary.'''
+
+
 @expect('D300: Use """triple double quotes""" (found \'-quotes)')
-def lalskklkjllkjl():
+def single_quotes_raw():
     r'Summary.'
 
 
+@expect('D300: Use """triple double quotes""" (found \'-quotes)')
+def single_quotes_raw_uppercase():
+    R'Summary.'
+
+
+@expect('D300: Use """triple double quotes""" (found \'-quotes)')
 @expect('D301: Use r""" if any backslashes in a docstring')
-def lalsksdewnlkjl():
+def single_quotes_raw_uppercase_backslash():
+    R'Sum\mary.'
+
+
+@expect('D301: Use r""" if any backslashes in a docstring')
+def double_quotes_backslash():
     """Sum\\mary."""
+
+
+@expect('D301: Use r""" if any backslashes in a docstring')
+def double_quotes_backslash_uppercase():
+    R"""Sum\\mary."""
 
 
 if sys.version_info[0] <= 2:
     @expect('D302: Use u""" for Unicode docstrings')
-    def lasewnlkjl():
+    def unicode_unmarked():
         """Юникод."""
 
 


### PR DESCRIPTION
While PEP 257 suggests to use lowercase literals, Python allows uppercase literals as string prefixes.

Unlike D301 and 302, error code D300 is not reported if uppercase docstring prefixes are being used (e.g., `R'''...'''`). The current implementation of D300 also causes a false positive for uppercase literals with double quotes (e.g., `R"""Sum\\mary."""`), and detects the quotes incorrectly for a `ur'''...'''` docstring prefix. 

This proposes a more robust implementation for D300 and adds some uppercase tests for D301 and ~~D302~~, which they already pass.

EDIT: For the sake of simplicity, the D302 uppercase literal test will be included in another PR.
