### PR TITLE
Check for D302 if at Python 3.3+ and using explicit unicode prefix.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -7,6 +7,9 @@ Release Notes
 Current Development Version
 ---------------------------
 
+* The error code D302 is now also being reported for Python versions
+  3.3 and following (#178).
+
 * The error code D300 is now also being reported if a docstring has
   uppercase literals (``R`` or ``U``) as prefix (#176).
 

--- a/src/pydocstyle.py
+++ b/src/pydocstyle.py
@@ -1592,9 +1592,11 @@ class PEP257Checker(object):
 
         # Just check that docstring is unicode, check_triple_double_quotes
         # ensures the correct quotes.
-        if docstring and sys.version_info[0] <= 2:
-            if not is_ascii(docstring) and not docstring.startswith(
-                    ('u', 'ur')):
+        if docstring and not docstring.startswith('u'):
+            if sys.version_info < (3, 0) and not is_ascii(docstring):
+                return D302()
+
+            if sys.version_info >= (3, 3) and docstring.startswith('U'):
                 return D302()
 
     @check_for(Definition)


### PR DESCRIPTION
Since Python 3.3, Unicode string literal prefixes have been reintroduced, but D302 is exclusively reported for Python 2.

This proposes an implementation to report D302 if and only if a Unicode prefix has been explicitly added to the docstring for Python 3. The behavior of D302 for Python 2 is not changed.

This also adds some test cases to the already existing Unicode integration test (pypy3 currently implements Python 3.2, only). To avoid code duplication, this has been implemented as a single test case with multiple checks. Let me know if you would like to see those in separate tests.
