### PR TITLE
Match argument to passed in keyword argument

### DIFF
--- a/src/pydocstyle.py
+++ b/src/pydocstyle.py
@@ -1298,7 +1298,7 @@ def setup_stream_handlers(conf):
     log.addHandler(stderr_handler)
 
 
-def run_pydocstyle(used_pep257=False):
+def run_pydocstyle(use_pep257=False):
     log.setLevel(logging.DEBUG)
     conf = ConfigurationParser()
     setup_stream_handlers(conf.get_default_run_configuration())
@@ -1313,7 +1313,7 @@ def run_pydocstyle(used_pep257=False):
     # Reset the logger according to the command line arguments
     setup_stream_handlers(run_conf)
 
-    if used_pep257:
+    if use_pep257:
         log.warning("Deprecation Warning:\n"
                     "pep257 has been renamed to pydocstyle and the use of the "
                     "pep257 executable is deprecated and will be removed in "


### PR DESCRIPTION
The couple times that run_pydocstyle is used calls it with "use_pep257"
instead of "used_pep257". This makes it consistent by using the active
present-tense voice instead of the past-tense voice.