### PR TITLE
Stop converting the filename to lowercase

### DIFF
--- a/src/pydocstyle.py
+++ b/src/pydocstyle.py
@@ -151,10 +151,6 @@ class Module(Definition):
     module = property(lambda self: self)
     all = property(lambda self: self._all)
 
-    def __init__(self, *args, **kwargs):
-        super(Module, self).__init__(*args, **kwargs)
-        self.name = self.name.lower()
-
     def __str__(self):
         return 'at module level'
 

--- a/src/tests/test_cases/test.py
+++ b/src/tests/test_cases/test.py
@@ -339,5 +339,5 @@ def outer_function():
         """Do inner something."""
         return 0
 
-expect(__file__.lower() if __file__[-1] != 'c' else __file__[:-1].lower(),
+expect(__file__ if __file__[-1] != 'c' else __file__[:-1],
        'D100: Missing docstring in public module')

--- a/src/tests/test_definitions.py
+++ b/src/tests/test_definitions.py
@@ -253,26 +253,25 @@ def test_token_stream():
     assert stream.line == 1
 
 
-def test_pep257():
+@pytest.mark.parametrize('test_case', [
+    'test',
+    'unicode_literals',
+    'nested_class',
+    'capitalization',
+    'comment_after_def_bug',
+    'multi_line_summary_start',
+])
+def test_pep257(test_case):
     """Run domain-specific tests from test.py file."""
-    test_cases = (
-        'test',
-        'unicode_literals',
-        'nested_class',
-        'capitalization',
-        'comment_after_def_bug',
-        'multi_line_summary_start'
-    )
-    for test_case in test_cases:
-        case_module = __import__('test_cases.{0}'.format(test_case),
-                                 globals=globals(),
-                                 locals=locals(),
-                                 fromlist=['expectation'],
-                                 level=1)
-        results = list(check([os.path.join(os.path.dirname(__file__),
-                                           'test_cases', test_case + '.py')],
-                             select=set(ErrorRegistry.get_error_codes())))
-        for error in results:
-            assert isinstance(error, Error)
-        results = set([(e.definition.name, e.message) for e in results])
-        assert case_module.expectation.expected == results
+    case_module = __import__('test_cases.{0}'.format(test_case),
+                             globals=globals(),
+                             locals=locals(),
+                             fromlist=['expectation'],
+                             level=1)
+    results = list(check([os.path.join(os.path.dirname(__file__),
+                                       'test_cases', test_case + '.py')],
+                         select=set(ErrorRegistry.get_error_codes())))
+    for error in results:
+        assert isinstance(error, Error)
+    results = set([(e.definition.name, e.message) for e in results])
+    assert case_module.expectation.expected == results

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -21,7 +21,7 @@ from .. import pydocstyle
 __all__ = ()
 
 
-class TestEnv(object):
+class FakeTestEnv(object):
     """An isolated environment where pydocstyle can be run.
 
     Since running pydocstyle as a script is affected by local config files,
@@ -109,7 +109,7 @@ def install_package(request):
 
 @pytest.yield_fixture(scope="function", params=('pydocstyle', 'pep257'))
 def env(request):
-    with TestEnv(request.param) as test_env:
+    with FakeTestEnv(request.param) as test_env:
         yield test_env
 
 pytestmark = pytest.mark.usefixtures("install_package")
@@ -854,7 +854,7 @@ def test_config_file_nearest_match_re(env):
 
 
 def test_pep257_entry_point():
-    with TestEnv('pep257') as env:
+    with FakeTestEnv('pep257') as env:
         _, err, code = env.invoke()
         assert code == 0
         assert 'Deprecation Warning' in err, err

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ commands=sphinx-build -b html . _build
 pep8ignore =
     test.py E701 E704
 norecursedirs = docs .tox
+addopts = -rw
 
 [pep257]
 inherit = false


### PR DESCRIPTION
This leads to problems for tools integrating with pydocstyle, e.g., atom
linter-pydocstyle

Closes #179 

cc @BrnoPCmaniak