### PR TITLE
Added D404: First word of the docstring should not be `This`

### DIFF
--- a/docs/error_codes.rst
+++ b/docs/error_codes.rst
@@ -15,4 +15,4 @@ check only error codes that are part of the `PEP257
 <http://www.python.org/dev/peps/pep-0257/>`_ official convention.
 
 All of the above error codes are checked for by default except for D203,
-D212 and D213.
+D212, D213 and D404.

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -7,9 +7,16 @@ Release Notes
 Current Development Version
 ---------------------------
 
+New Features
+
 * Added the optional error codes D212 and D213, for checking whether
   the summary of a multi-line docstring starts at the first line,
   respectively at the second line (#174).
+
+* Added D404 - First word of the docstring should not be `This`. It is turned
+  off by default (#183).
+
+Bug Fixes
 
 * The error code D300 is now also being reported if a docstring has
   uppercase literals (``R`` or ``U``) as prefix (#176).

--- a/src/pydocstyle.py
+++ b/src/pydocstyle.py
@@ -703,6 +703,8 @@ D402 = D4xx.create_error('D402', 'First line should not be the function\'s '
                                  '"signature"')
 D403 = D4xx.create_error('D403', 'First word of the first line should be '
                                  'properly capitalized', '%r, not %r')
+D404 = D4xx.create_error('D404', 'First word of the docstring should not '
+                                 'be `This`')
 
 
 class AttrDict(dict):
@@ -711,8 +713,10 @@ class AttrDict(dict):
 
 
 conventions = AttrDict({
-    'pep257': set(ErrorRegistry.get_error_codes()) - set(['D203', 'D212',
-                                                          'D213'])
+    'pep257': set(ErrorRegistry.get_error_codes()) - set(['D203',
+                                                          'D212',
+                                                          'D213',
+                                                          'D404'])
 })
 
 
@@ -1435,7 +1439,6 @@ class PEP257Checker(object):
         There's no blank line either before or after the docstring.
 
         """
-        # NOTE: This does not take into account functions with groups of code.
         if docstring:
             before, _, after = function.source.partition(docstring)
             blanks_before = list(map(is_blank, before.split('\n')[:-1]))
@@ -1683,6 +1686,19 @@ class PEP257Checker(object):
                     return
             if first_word != first_word.capitalize():
                 return D403(first_word.capitalize(), first_word)
+
+    @check_for(Definition)
+    def check_starts_with_this(self, function, docstring):
+        """D404: First word of the docstring should not be `This`.
+
+        Docstrings should use short, simple language. They should not begin
+        with "This class is [..]" or "This module contains [..]".
+
+        """
+        if docstring:
+            first_word = ast.literal_eval(docstring).split()[0]
+            if first_word.lower() == 'this':
+                return D404()
 
     # Somewhat hard to determine if return value is mentioned.
     # @check(Function)

--- a/src/tests/test_cases/unicode_literals.py
+++ b/src/tests/test_cases/unicode_literals.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""This is a module."""
+"""A module."""
 
 from __future__ import unicode_literals
 from .expected import Expectation

--- a/src/tests/test_decorators.py
+++ b/src/tests/test_decorators.py
@@ -13,7 +13,7 @@ import textwrap
 from .. import pydocstyle
 
 
-class TestParser:
+class TestParser(object):
     """Check parsing of Python source code."""
 
     def test_parse_class_single_decorator(self):

--- a/src/tests/test_definitions.py
+++ b/src/tests/test_definitions.py
@@ -253,8 +253,8 @@ def test_token_stream():
     assert stream.line == 1
 
 
-def test_pep257():
-    """Run domain-specific tests from test.py file."""
+def test_example_files():
+    """Run domain-specific tests from test case files."""
     test_cases = (
         'test',
         'unicode_literals',
@@ -275,4 +275,4 @@ def test_pep257():
         for error in results:
             assert isinstance(error, Error)
         results = set([(e.definition.name, e.message) for e in results])
-        assert case_module.expectation.expected == results
+        assert case_module.expectation.expected == results, test_case

--- a/tox.ini
+++ b/tox.ini
@@ -28,3 +28,4 @@ addopts = -rw
 [pep257]
 inherit = false
 convention = pep257
+add-select = D404


### PR DESCRIPTION
This is intended to make docstrings shorter and to the point, as they should not start with "This module contains [..]" or "This class represents [..]".

It is unchecked by default as it is not part of the PEP257 standard.