### PR TITLE
Adding D405 and D406 to check return values/args

### DIFF
--- a/src/pydocstyle.py
+++ b/src/pydocstyle.py
@@ -1760,11 +1760,16 @@ class PEP257Checker(object):
         if not docstring:
             return
 
-        # ignore functions that already mention return
-        # FIXME: this is only checking if "return" is anywhere in
-        # the docstring, not if the return is properly documented.
-        if 'return' in docstring.lower():
-            return
+        return_styles = [
+            ':returns:',  # sphinx
+            'Returns:',  # napoleon
+            '@return:',  # twisted
+        ]
+
+        # ignore functions where any line starts with a valid return style
+        for line in docstring.split("\n"):
+            if line.strip().split()[:1] in return_styles:
+                return
 
         tree = ast.parse(function.source.strip())
 

--- a/src/tests/test_cases/test.py
+++ b/src/tests/test_cases/test.py
@@ -320,17 +320,22 @@ def docstring_start_in_same_line(): """First Line.
     """
 
 
+@expect("D406: Function arguments should be mentioned. (['x'])")
 def function_with_lambda_arg(x=lambda y: y):
     """A valid docstring."""
 
 
+@expect("D406: Function arguments should be mentioned. (['z'])")
 @expect('D213: Multi-line docstring summary should start at the second line')
-def a_following_valid_function(x=None):
+def a_following_valid_function(z=None):
     """Check for a bug where the previous function caused an assertion.
 
     The assertion was caused in the next function, so this one is necessary.
 
     """
+
+expect('inner_function',
+       "D405: Return value type should be mentioned. ('Num')")
 
 
 def outer_function():
@@ -338,6 +343,30 @@ def outer_function():
     def inner_function():
         """Do inner something."""
         return 0
+
+
+@expect("D405: Return value type should be mentioned. ('Num')")
+def return_inside_if():
+    """Do something."""
+    a = False
+    if a:
+        return 1
+    return
+
+
+@expect("D406: Function arguments should be mentioned. (['z'])")
+def nested_class(z=None):
+    """A docstring."""
+    @expect('D211: No blank lines allowed before class docstring (found 1)')
+    class InternalClass(object):
+
+        """Class Docstring."""
+
+        @expect("D405: Return value type should be mentioned. ('Num')")
+        def internal_method(self=None):
+            """Internal Docstring."""
+            return 5
+
 
 expect(__file__ if __file__[-1] != 'c' else __file__[:-1],
        'D100: Missing docstring in public module')

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -154,7 +154,7 @@ def test_ignore_list():
             return foo
     ''')
     expected_error_codes = set(('D100', 'D400', 'D401', 'D205', 'D209',
-                                'D210', 'D403'))
+                                'D210', 'D403', 'D405', 'D406'))
     mock_open = mock.mock_open(read_data=function_to_check)
     from .. import pydocstyle
     with mock.patch.object(


### PR DESCRIPTION
D405 will error if a function has a return statement but does not
define a return value in the docstring.

D406 will error if a function has arguments defined but not mentioned
in the docstring.
