### PR TITLE
Allow skipping decorated functions

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -10,6 +10,7 @@ Current Development Version
 Major Updates
 
 * Support for Python 2.6 has been dropped (#206, #217).
+* Decorator-based skipping via ``--ignore-decorators`` has been added (#204).
 
 1.1.1 - October 4th, 2016
 -------------------------

--- a/docs/snippets/cli.rst
+++ b/docs/snippets/cli.rst
@@ -36,6 +36,11 @@ Usage
                             search only dirs that exactly match <pattern> regular
                             expression; default is --match-dir='[^\.].*', which
                             matches all dirs that don't start with a dot
+      --ignore-decorators=<decorators>
+                            ignore any functions or methods that are decorated by
+                            a function with a name fitting the <decorators>
+                            regular expression; default is --ignore-decorators=''
+                            which does not ignore any decorated functions.
 
 
 Return Code

--- a/docs/snippets/config.rst
+++ b/docs/snippets/config.rst
@@ -32,6 +32,7 @@ Available options are:
 * ``add_ignore``
 * ``match``
 * ``match_dir``
+* ``ignore_decorators``
 
 See the :ref:`cli_usage` section for more information.
 

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -9,7 +9,6 @@ from re import compile as re
 
 from . import violations
 from .config import IllegalConfiguration
-# TODO: handle
 from .parser import (Package, Module, Class, NestedClass, Definition, AllError,
                      Method, Function, NestedFunction, Parser, StringIO)
 from .utils import log, is_blank
@@ -50,10 +49,11 @@ class PEP257Checker(object):
             for this_check in self.checks:
                 terminate = False
                 if isinstance(definition, this_check._check_for):
-                    if definition.skipped_error_codes != 'all' and \
-                            not any(ignore_decorators is not None and
-                                    len(ignore_decorators.findall(dec.name))
-                                    for dec in definition.decorators):
+                    skipping_all = (definition.skipped_error_codes == 'all')
+                    decorator_skip = ignore_decorators is not None and any(
+                        len(ignore_decorators.findall(dec.name)) > 0
+                        for dec in definition.decorators)
+                    if not skipping_all and not decorator_skip:
                         error = this_check(None, definition,
                                            definition.docstring)
                     else:

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -10,7 +10,8 @@ from re import compile as re
 from . import violations
 from .config import IllegalConfiguration
 # TODO: handle
-from .parser import *
+from .parser import (Package, Module, Class, NestedClass, Definition, AllError,
+                     Method, Function, NestedFunction, Parser, StringIO)
 from .utils import log, is_blank
 
 
@@ -43,26 +44,30 @@ class PEP257Checker(object):
 
     """
 
-    def check_source(self, source, filename):
+    def check_source(self, source, filename, ignore_decorators):
         module = parse(StringIO(source), filename)
         for definition in module:
-            for check in self.checks:
+            for this_check in self.checks:
                 terminate = False
-                if isinstance(definition, check._check_for):
-                    if definition.skipped_error_codes != 'all':
-                        error = check(None, definition, definition.docstring)
+                if isinstance(definition, this_check._check_for):
+                    if definition.skipped_error_codes != 'all' and \
+                            not any(ignore_decorators is not None and
+                                    len(ignore_decorators.findall(dec.name))
+                                    for dec in definition.decorators):
+                        error = this_check(None, definition,
+                                           definition.docstring)
                     else:
                         error = None
                     errors = error if hasattr(error, '__iter__') else [error]
                     for error in errors:
                         if error is not None and error.code not in \
                                 definition.skipped_error_codes:
-                            partition = check.__doc__.partition('.\n')
+                            partition = this_check.__doc__.partition('.\n')
                             message, _, explanation = partition
                             error.set_context(explanation=explanation,
                                               definition=definition)
                             yield error
-                            if check._terminal:
+                            if this_check._terminal:
                                 terminate = True
                                 break
                 if terminate:
@@ -70,9 +75,9 @@ class PEP257Checker(object):
 
     @property
     def checks(self):
-        all = [check for check in vars(type(self)).values()
-               if hasattr(check, '_check_for')]
-        return sorted(all, key=lambda check: not check._terminal)
+        all = [this_check for this_check in vars(type(self)).values()
+               if hasattr(this_check, '_check_for')]
+        return sorted(all, key=lambda this_check: not this_check._terminal)
 
     @check_for(Definition, terminal=True)
     def check_docstring_missing(self, definition, docstring):
@@ -387,7 +392,7 @@ class PEP257Checker(object):
 parse = Parser()
 
 
-def check(filenames, select=None, ignore=None):
+def check(filenames, select=None, ignore=None, ignore_decorators=None):
     """Generate docstring errors that exist in `filenames` iterable.
 
     By default, the PEP-257 convention is checked. To specifically define the
@@ -432,7 +437,8 @@ def check(filenames, select=None, ignore=None):
         try:
             with tokenize_open(filename) as file:
                 source = file.read()
-            for error in PEP257Checker().check_source(source, filename):
+            for error in PEP257Checker().check_source(source, filename,
+                                                      ignore_decorators):
                 code = getattr(error, 'code', None)
                 if code in checked_codes:
                     yield error

--- a/src/pydocstyle/cli.py
+++ b/src/pydocstyle/cli.py
@@ -45,8 +45,10 @@ def run_pydocstyle(use_pep257=False):
 
     errors = []
     try:
-        for filename, checked_codes in conf.get_files_to_check():
-            errors.extend(check((filename,), select=checked_codes))
+        for filename, checked_codes, ignore_decorators in \
+                conf.get_files_to_check():
+            errors.extend(check((filename,), select=checked_codes,
+                                ignore_decorators=ignore_decorators))
     except IllegalConfiguration:
         # An illegal configuration file was found during file generation.
         return ReturnCode.invalid_options

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -64,11 +64,13 @@ class ConfigurationParser(object):
     """
 
     CONFIG_FILE_OPTIONS = ('convention', 'select', 'ignore', 'add-select',
-                           'add-ignore', 'match', 'match-dir')
+                           'add-ignore', 'match', 'match-dir',
+                           'ignore-decorators')
     BASE_ERROR_SELECTION_OPTIONS = ('ignore', 'select', 'convention')
 
     DEFAULT_MATCH_RE = '(?!test_).*\.py'
     DEFAULT_MATCH_DIR_RE = '[^\.].*'
+    DEFAULT_IGNORE_DECORATORS_RE = ''
     DEFAULT_CONVENTION = conventions.pep257
 
     PROJECT_CONFIG_FILES = (
@@ -139,11 +141,20 @@ class ConfigurationParser(object):
             match_dir_func = re(config.match_dir + '$').match
             return match_func, match_dir_func
 
+        def _get_ignore_dec(config):
+            """Return the `ignore_decorators` as None or regex."""
+            if config.ignore_decorators:  # not None and not ''
+                ignore_decorators = re(config.ignore_decorators)
+            else:
+                ignore_decorators = None
+            return ignore_decorators
+
         for name in self._arguments:
             if os.path.isdir(name):
                 for root, dirs, filenames in os.walk(name):
                     config = self._get_config(root)
                     match, match_dir = _get_matches(config)
+                    ignore_dec = _get_ignore_dec(config)
 
                     # Skip any dirs that do not match match_dir
                     dirs[:] = [dir for dir in dirs if match_dir(dir)]
@@ -151,19 +162,21 @@ class ConfigurationParser(object):
                     for filename in filenames:
                         if match(filename):
                             full_path = os.path.join(root, filename)
-                            yield full_path, list(config.checked_codes)
+                            yield (full_path, list(config.checked_codes),
+                                   ignore_dec)
             else:
                 config = self._get_config(name)
                 match, _ = _get_matches(config)
+                ignore_dec = _get_ignore_dec(config)
                 if match(name):
-                    yield name, list(config.checked_codes)
+                    yield (name, list(config.checked_codes), ignore_dec)
 
     # --------------------------- Private Methods -----------------------------
 
     def _get_config(self, node):
         """Get and cache the run configuration for `node`.
 
-        If no configuration exists (not local and not for the parend node),
+        If no configuration exists (not local and not for the parent node),
         returns and caches a default configuration.
 
         The algorithm:
@@ -298,14 +311,12 @@ class ConfigurationParser(object):
 
         self._set_add_options(error_codes, child_options)
 
-        match = child_options.match \
-            if child_options.match is not None else parent_config.match
-        match_dir = child_options.match_dir \
-            if child_options.match_dir is not None else parent_config.match_dir
-
-        return CheckConfiguration(checked_codes=error_codes,
-                                  match=match,
-                                  match_dir=match_dir)
+        kwargs = dict(checked_codes=error_codes)
+        for key in ('match', 'match_dir', 'ignore_decorators'):
+            kwargs[key] = getattr(child_options, key) \
+                if getattr(child_options, key) is not None \
+                else getattr(parent_config, key)
+        return CheckConfiguration(**kwargs)
 
     def _parse_args(self, args=None, values=None):
         """Parse the options using `self._parser` and reformat the options."""
@@ -328,21 +339,17 @@ class ConfigurationParser(object):
         set for the checked codes.
 
         """
-        match = cls.DEFAULT_MATCH_RE \
-            if options.match is None and use_dafaults \
-            else options.match
-
-        match_dir = cls.DEFAULT_MATCH_DIR_RE \
-            if options.match_dir is None and use_dafaults \
-            else options.match_dir
-
         checked_codes = None
 
         if cls._has_exclusive_option(options) or use_dafaults:
             checked_codes = cls._get_checked_errors(options)
 
-        return CheckConfiguration(checked_codes=checked_codes,
-                                  match=match, match_dir=match_dir)
+        kwargs = dict(checked_codes=checked_codes)
+        for key in ('match', 'match_dir', 'ignore_decorators'):
+            kwargs[key] = getattr(cls, 'DEFAULT_{0}_RE'.format(key.upper())) \
+                if getattr(options, key) is None and use_dafaults \
+                else getattr(options, key)
+        return CheckConfiguration(**kwargs)
 
     @classmethod
     def _get_section_name(cls, parser):
@@ -518,12 +525,20 @@ class ConfigurationParser(object):
                      "matches all dirs that don't start with "
                      "a dot").format(cls.DEFAULT_MATCH_DIR_RE))
 
+        # Decorators
+        option('--ignore-decorators', metavar='<decorators>', default=None,
+               help=("ignore any functions or methods that are decorated "
+                     "by a function with a name fitting the <decorators> "
+                     "regular expression; default is --ignore-decorators='{0}'"
+                     "which does not ignore any decorated functions."
+                     .format(cls.DEFAULT_IGNORE_DECORATORS_RE)))
         return parser
 
 
 # Check configuration - used by the ConfigurationParser class.
 CheckConfiguration = namedtuple('CheckConfiguration',
-                                ('checked_codes', 'match', 'match_dir'))
+                                ('checked_codes', 'match', 'match_dir',
+                                 'ignore_decorators'))
 
 
 class IllegalConfiguration(Exception):

--- a/src/tests/test_cases/test.py
+++ b/src/tests/test_cases/test.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 # No docstring, so we can test D100
+from functools import wraps
 import os
 import sys
 from .expected import Expectation
@@ -361,6 +362,12 @@ def docstring_bad_ignore_one():  # noqa: D400,D401
 @expect("D401: First line should be in imperative mood ('Run', not 'Runs')")
 def docstring_ignore_violations_of_pydocstyle_D400_and_PEP8_E501_but_catch_D401():  # noqa: E501,D400
     """Runs something"""
+    pass
+
+
+@wraps(docstring_bad_ignore_one)
+def bad_decorated_function():
+    """Bad (E501) but decorated"""
     pass
 
 expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),

--- a/src/tests/test_definitions.py
+++ b/src/tests/test_definitions.py
@@ -1,6 +1,7 @@
 """Old parser tests."""
 
 import os
+import re
 import pytest
 from pydocstyle.violations import Error, ErrorRegistry
 from pydocstyle.checker import check
@@ -278,7 +279,8 @@ def test_pep257(test_case):
                                   'test_cases',
                                   test_case + '.py')
     results = list(check([test_case_file],
-                         select=set(ErrorRegistry.get_error_codes())))
+                         select=set(ErrorRegistry.get_error_codes()),
+                         ignore_decorators=re.compile('wraps')))
     for error in results:
         assert isinstance(error, Error)
     results = set([(e.definition.name, e.message) for e in results])


### PR DESCRIPTION
@Nurdok I think you talked about adding an option like this, see if it's what you have in mind. A user can now do e.g.:

```
--ignore-decorators=wraps
```
Or in my case, I will add this to my config:
```
ignore-decorators = copy_.*_doc_to_.*
```