### PR TITLE
Add CLI option for custom config file paths

### DIFF
--- a/docs/snippets/cli.rst
+++ b/docs/snippets/cli.rst
@@ -15,6 +15,7 @@ Usage
       -d, --debug           print debug information
       -v, --verbose         print status information
       --count               print total number of errors to stdout
+      --config=<path>       use a config file in another location
       --select=<codes>      choose the basic list of checked errors by specifying
                             which errors to check for (with a list of comma-
                             separated error codes). for example:

--- a/docs/snippets/config.rst
+++ b/docs/snippets/config.rst
@@ -12,6 +12,10 @@ file specified above *in that exact order*. If a configuration file was not
 found, it keeps looking for one up the directory tree until one is found or
 uses the default configuration.
 
+``pydocstyle`` also has a `--config`` CLI option that takes precedence over
+the other config files in its specific directory. The specified config file
+only takes precedence over others in its own directory.
+
 .. note::
 
     For backwards compatibility purposes, **pydocstyle** supports configuration

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -195,7 +195,20 @@ class ConfigurationParser(object):
         if path in self._cache:
             return self._cache[path]
 
-        config_file = self._get_config_file_in_folder(path)
+        if self._options.config_location is None:
+            # No specific config file specified on the command line.
+            # Search the directory for generic filenames.
+            config_file = self._get_config_file_in_folder(path)
+        else:
+            # Look for the config file from the command line option.
+            cli_config_dir = os.path.dirname(self._options.config_location)
+            if os.path.abspath(cli_config_dir) == os.getcwd():
+                # We're in the specified config file's directory.
+                # Take that one instead of searching for a generic name.
+                config_file = self._options.config_location
+            else:
+                # Search anyway since we're not in the right directory.
+                config_file = self._get_config_file_in_folder(path)
 
         if config_file is None:
             parent_dir, tail = os.path.split(path)
@@ -483,6 +496,8 @@ class ConfigurationParser(object):
                help='print status information')
         option('--count', action='store_true', default=False,
                help='print total number of errors to stdout')
+        option('--config', metavar='<path>', dest='config_location',
+               help='use a config file in another location')
 
         # Error check options
         option('--select', metavar='<codes>', default=None,


### PR DESCRIPTION
Added a section in the docs for it too. It overrides the generic-named config files in the custom file's folder.
