### PR TITLE
Ignore SyntaxError while parsing

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,6 +11,10 @@ Major Updates
 
 * Support for Python 2.6 has been dropped (#206, #217).
 
+Bug Fixes
+
+* Made parser more robust to bad source files (#168, #214)
+
 1.1.1 - October 4th, 2016
 -------------------------
 

--- a/src/pydocstyle/parser.py
+++ b/src/pydocstyle/parser.py
@@ -209,13 +209,21 @@ class TokenStream(object):
         self._generator = tk.generate_tokens(filelike.readline)
         self.current = Token(*next(self._generator, None))
         self.line = self.current.start[0]
+        self.log = logging.getLogger()
 
     def move(self):
         previous = self.current
-        current = next(self._generator, None)
+        current = self._next_from_generator()
         self.current = None if current is None else Token(*current)
         self.line = self.current.start[0] if self.current else self.line
         return previous
+
+    def _next_from_generator(self):
+        try:
+            return next(self._generator, None)
+        except (SyntaxError, tk.TokenError):
+            self.log.warning('error generating tokens', exc_info=True)
+            return None
 
     def __iter__(self):
         while True:

--- a/src/tests/test_definitions.py
+++ b/src/tests/test_definitions.py
@@ -223,7 +223,7 @@ def test_import_parser():
             source_future_import_invalid7,
             source_future_import_invalid8,
             ), 1):
-        module = parse(StringIO(source_ucl), 'file_invalid{}.py'.format(i))
+        module = parse(StringIO(source_ucli), 'file_invalid{}.py'.format(i))
 
         assert Module('file_invalid{}.py'.format(i), _, 1,
                       _, _, None, _, _,

--- a/src/tests/test_definitions.py
+++ b/src/tests/test_definitions.py
@@ -126,6 +126,14 @@ source_future_import_invalid8 = """
 from __future__ import (, )
 """
 
+source_invalid_syntax = """
+while True:
+\ttry:
+    pass
+"""
+
+source_token_error = '['
+
 source_complex_all = '''
 import foo
 import bar
@@ -222,6 +230,8 @@ def test_import_parser():
             source_future_import_invalid6,
             source_future_import_invalid7,
             source_future_import_invalid8,
+            source_token_error,
+            source_invalid_syntax,
             ), 1):
         module = parse(StringIO(source_ucli), 'file_invalid{}.py'.format(i))
 


### PR DESCRIPTION
This is a partial fix for #168. With this change, the parser no longer crashes on test file [E90.py](https://github.com/PyCQA/pep8/blob/fed43c5/testsuite/E90.py).

Note that this is a pretty minimal fix. A potential future refactor to increase the robustness of the parser could be to use the null-object pattern and return a NullToken from `TokenStream.move` instead of `None`. In this way, any code that consumes `TokenStream.current` doesn't have to null-check the property value explicitly which should make the other issues mentioned in #168 go away.