### PR TITLE
Add option to override default error output format

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
+    'sphinx.ext.intersphinx',  # create links to other Python documentation
     'sphinxcontrib.issuetracker',  # autolinks issue numbers (like #78)
 ]
 
@@ -261,6 +262,11 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+# Add sphinx.ext.intersphinx mappings
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+}
 
 # sphinxcontrib.issuetracker settings
 issuetracker = 'github'

--- a/docs/snippets/cli.rst
+++ b/docs/snippets/cli.rst
@@ -3,6 +3,8 @@
 Usage
 ^^^^^
 
+.. highlight:: none
+
 .. code::
 
     Usage: pydocstyle [options] [<file|dir>...]
@@ -19,6 +21,8 @@ Usage
                             which errors to check for (with a list of comma-
                             separated error codes or prefixes). for example:
                             --select=D101,D2
+      --format=<format>     override default error format (ignores --explain and
+                            --source)
       --ignore=<codes>      choose the basic list of checked errors by specifying
                             which errors to ignore (with a list of comma-separated
                             error codes or prefixes). for example:
@@ -51,6 +55,71 @@ Usage
     will match. For example, running the command ``pydocstyle --ignore=D4``
     will ignore all docstring content issues as their error codes begining with
     "D4" (i.e. D400, D401, D402, D403, and D404).
+
+
+Error format
+^^^^^^^^^^^^
+
+The ``--format`` option allows to override the default error format, which
+controls how each error found is printed to the standard output. The error
+format uses the standard Python :ref:`format string syntax <formatstrings>` and
+can include the following placeholders:
+
+``code``
+    the error code, e.g. D101, D304, etc.
+``definition``
+    the type and name of the code section where the error occured
+``explanation``
+    an explanation of the rule the error violated
+``filename``
+    the path of the file in which the error occured
+``line``
+    the line number at which the error occured
+``lines``
+    the source code which exhibits the error
+``message``
+    the ``short_desc`` prefixed by ``code`` and a colon and followed by
+    additional error context, e.g. "D401: First line should be in imperative
+    mood ('Return', not 'Returns')"
+``short_desc``
+    the error message corresponding to the error code, e.g., for D103,
+    "Missing docstring in public function"
+
+The default error format, if neither the ``--explain`` nor the ``--source``
+options are given, is ``'{filename}:{line} {definition}:\n        {message}'``.
+
+
+Example usage
+#############
+
+Consider the following usage:
+
+.. code:: console
+
+    $ pydocstyle --format='{filename}#L{line:03}: {short_desc} ({code})' src/example.py
+
+This would output output each error formatted like the following example:
+
+.. code::
+
+    src/example.py#L001: Missing docstring in public module (D100)
+
+If you want to use a format string, which includes line-breaks or other
+non-printable characters, you might have to do some shell trickery to pass it
+correctly:
+
+.. code:: console
+
+    $ FMT=$(echo -e '\nFile:\t{filename}:{line}\nWhere:\t{definition}\nWhat:\t{message}')
+    $ pydocstyle --format="$FMT" src/example.py
+
+    File:	src/example.py:16
+    Where:	in public function `main`
+    What:	D103: Missing docstring in public function
+
+
+.. highlight:: python
+
 
 Return Code
 ^^^^^^^^^^^

--- a/docs/snippets/cli.rst
+++ b/docs/snippets/cli.rst
@@ -85,8 +85,9 @@ can include the following placeholders:
     the error message corresponding to the error code, e.g., for D103,
     "Missing docstring in public function"
 
-The default error format, if neither the ``--explain`` nor the ``--source``
-options are given, is ``'{filename}:{line} {definition}:\n        {message}'``.
+The default error format, if neither the ``--format`` nor the ``--explain`` or
+``--source`` options are given, is ``'{filename}:{line} {definition}:\n
+{message}'``.
 
 
 Example usage

--- a/docs/snippets/config.rst
+++ b/docs/snippets/config.rst
@@ -65,10 +65,9 @@ root), simply add ``inherit=false`` to your configuration file.
 Example
 #######
 
-.. code::
+.. code:: cfg
 
     [pydocstyle]
     inherit = false
     ignore = D100,D203,D405
     match = *.py
-

--- a/docs/snippets/in_file.rst
+++ b/docs/snippets/in_file.rst
@@ -8,7 +8,9 @@ specific functions or methods. The supported comments that can be added are:
    e.g. ``# noqa: D102,E501,D203``.
 
 For example, this will skip the check for a period at the end of a function
-docstring::
+docstring:
+
+.. code:: pycon
 
     >>> def bad_function():  # noqa: D400
     ...     """Omit a period in the docstring as an exception"""

--- a/src/pydocstyle/cli.py
+++ b/src/pydocstyle/cli.py
@@ -54,7 +54,7 @@ def run_pydocstyle():
         try:
             sys.stdout.write('%s\n' % error)
         except InvalidErrorFormat as exc:
-            sys.stdout.write('%s\n' % exc)
+            sys.stderr.write('%s\n' % exc)
             return ReturnCode.invalid_options
         count += 1
     if count == 0:

--- a/src/pydocstyle/cli.py
+++ b/src/pydocstyle/cli.py
@@ -2,10 +2,11 @@
 import logging
 import sys
 
+from .checker import check
+from .config import ConfigurationParser
+from .exceptions import IllegalConfiguration, InvalidErrorFormat
 from .utils import log
 from .violations import Error
-from .config import ConfigurationParser, IllegalConfiguration
-from .checker import check
 
 
 __all__ = ('main', )
@@ -36,6 +37,7 @@ def run_pydocstyle():
 
     Error.explain = run_conf.explain
     Error.source = run_conf.source
+    Error.format = run_conf.format
 
     errors = []
     try:
@@ -49,7 +51,11 @@ def run_pydocstyle():
 
     count = 0
     for error in errors:
-        sys.stdout.write('%s\n' % error)
+        try:
+            sys.stdout.write('%s\n' % error)
+        except InvalidErrorFormat as exc:
+            sys.stdout.write('%s\n' % exc)
+            return ReturnCode.invalid_options
         count += 1
     if count == 0:
         exit_code = ReturnCode.no_violations_found

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -37,7 +37,9 @@ class ConfigurationParser(object):
     ------------------
     Responsible for deciding things that are related to the user interface,
     e.g. verbosity, debug options, etc.
-    All run configurations default to `False` and are decided only by CLI.
+
+    All run configurations default to `False` resp. `None` and are decided only
+    by CLI.
 
     Check Configurations:
     --------------------

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -13,6 +13,7 @@ except ImportError:  # Python 2.x
     from configparser import RawConfigParser
 
 
+from .exceptions import IllegalConfiguration
 from .utils import __version__, log
 from .violations import ErrorRegistry, conventions
 
@@ -503,6 +504,9 @@ class ConfigurationParser(object):
                help='show explanation of each error')
         option('-s', '--source', action='store_true', default=False,
                help='show source for each error')
+        option('--format', metavar='<format>', default=None,
+               help='override default error format (ignores --explain and '
+                    '--source)')
         option('-d', '--debug', action='store_true', default=False,
                help='print debug information')
         option('-v', '--verbose', action='store_true', default=False,
@@ -560,13 +564,7 @@ CheckConfiguration = namedtuple('CheckConfiguration',
                                  'ignore_decorators'))
 
 
-class IllegalConfiguration(Exception):
-    """An exception for illegal configurations."""
-
-    pass
-
-
 # General configurations for pydocstyle run.
 RunConfiguration = namedtuple('RunConfiguration',
-                              ('explain', 'source', 'debug',
+                              ('explain', 'source', 'format', 'debug',
                                'verbose', 'count'))

--- a/src/pydocstyle/exceptions.py
+++ b/src/pydocstyle/exceptions.py
@@ -1,0 +1,11 @@
+"""Custom exceptions."""
+
+
+class IllegalConfiguration(Exception):
+    """An exception for illegal configurations."""
+    pass
+
+
+class InvalidErrorFormat(IllegalConfiguration):
+    """An execption for an invalid error format string."""
+    pass

--- a/src/tests/test_violations.py
+++ b/src/tests/test_violations.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the pydocstyle.violations module.
+
+Use tox or py.test to run the test-suite.
+"""
+
+from __future__ import with_statement
+
+import pytest
+from mock import MagicMock
+
+from pydocstyle import violations
+from pydocstyle.exceptions import InvalidErrorFormat
+
+
+MockModule = MagicMock(
+    start=1,
+    end=999,
+    _slice=slice(0, None),
+    _source=["My hovercraft is full of eels"],
+    __str__=MagicMock(return_value="at module level"))
+MockModule.name = 'hovercraft.py'
+MockModule.module = MockModule
+
+
+def test_default_error_format():
+    """Test that if Error.format is None the default output format is used."""
+    err = violations.D100()
+    err.set_context(MockModule, '')
+
+    assert err.format is None
+    assert str(err) == ("hovercraft.py:1 at module level:\n"
+                        "        D100: Missing docstring in public module")
+
+
+def test_default_error_format_explain():
+    """Test that if Error.explain is True the output includes explanantion."""
+    err = violations.D100()
+    err.set_context(MockModule, "Thou shalt have module docstrings!")
+    err.explain = True
+
+    assert err.format is None
+    assert err.source is False
+    assert str(err) == ("hovercraft.py:1 at module level:\n"
+                        "        D100: Missing docstring in public module\n\n"
+                        "Thou shalt have module docstrings!\n\n")
+
+
+def test_default_error_format_source():
+    """Test that if Error.source is True the output includes source lines."""
+    err = violations.D100()
+    err.set_context(MockModule, '')
+    err.source = True
+
+    assert err.format is None
+    assert err.explain is False
+    assert str(err) == ("hovercraft.py:1 at module level:\n"
+                        "        D100: Missing docstring in public module\n\n"
+                        "16: My hovercraft is full of eels    "
+                        " 1: My hovercraft is full of eels\n")
+
+
+def test_default_error_format_explain_and_source():
+    """Test that Error.explain and Error.source can be combined."""
+    err = violations.D100()
+    err.set_context(MockModule, "Thou shalt have module docstrings!")
+    err.explain = True
+    err.source = True
+
+    assert err.format is None
+    assert str(err) == ("hovercraft.py:1 at module level:\n"
+                        "        D100: Missing docstring in public module\n\n"
+                        "Thou shalt have module docstrings!\n\n"
+                        "16: My hovercraft is full of eels    "
+                        " 1: My hovercraft is full of eels\n")
+
+
+@pytest.mark.parametrize('error,format,output,explanation', [
+    (violations.D100, "{filename}#L{line:03}: {short_desc} ({code})",
+     "hovercraft.py#L001: Missing docstring in public module (D100)", ""),
+    (violations.D100, "{code}", "D100", ""),
+    (violations.D100, "{definition}", "at module level", ""),
+    (violations.D100, "{explanation}", "Docstrings please.",
+     "Docstrings please."),
+    (violations.D100, "{filename}", "hovercraft.py", ""),
+    (violations.D100, "{line}", "1", ""),
+    (violations.D100, "{lines}",
+     "16: My hovercraft is full of eels     1: My hovercraft is full of eels",
+     ""),
+    (violations.D100, "{message}", "D100: Missing docstring in public module",
+     ""),
+    (violations.D100, "{short_desc}", "Missing docstring in public module", "")
+])
+def test_error_format(error, explanation, format, output):
+    """Test that setting Error.format defines output format correctly."""
+    err = error()
+    err.set_context(MockModule, explanation)
+    err.format = format
+
+    assert str(err) == output
+
+
+@pytest.mark.parametrize('format,msg', [
+    ('{foo}', "'foo'"),
+    ('{message.foo}', "'str' object has no attribute 'foo'"),
+    ('{line:s}', "Unknown format code 's' for object of type 'int'"),
+])
+def test_error_format_key_error(format, msg):
+    """Test that errors in Error.format are turned into InvalidErrorFormat."""
+    err = violations.D100()
+    err.set_context(MockModule, '')
+    err.format = format
+
+    with pytest.raises(InvalidErrorFormat) as excinfo:
+        str(err)
+
+    expected = "Invalid error format '{}': {}".format(format, msg)
+    assert str(excinfo.value) == expected

--- a/src/tests/test_violations.py
+++ b/src/tests/test_violations.py
@@ -6,6 +6,8 @@ Use tox or py.test to run the test-suite.
 
 from __future__ import with_statement
 
+import sys
+
 import pytest
 from mock import MagicMock
 
@@ -13,6 +15,9 @@ from pydocstyle import violations
 from pydocstyle.exceptions import InvalidErrorFormat
 
 
+SKIP_PYPY = pytest.mark.skipif(
+    getattr(sys, 'subversion', ['CPython'])[0] == 'PyPy',
+    reason="PyPy exception messages differ")
 MockModule = MagicMock(
     start=1,
     end=999,
@@ -103,7 +108,7 @@ def test_error_format(error, explanation, format, output):
 @pytest.mark.parametrize('format,msg', [
     ('{foo}', "'foo'"),
     ('{message.foo}', "'str' object has no attribute 'foo'"),
-    ('{line:s}', "Unknown format code 's' for object of type 'int'"),
+    SKIP_PYPY(('{line:s}', "Unknown format code 's' for object of type 'int'"))
 ])
 def test_error_format_key_error(format, msg):
     """Test that errors in Error.format are turned into InvalidErrorFormat."""


### PR DESCRIPTION
This brings PR #115 up-to-date with the current sources and improves the documentation for it.

This change required two changes in some indirectly related parts of the code:

* In the Sphinx docs the intersphinx extension is enabled and configured in `conf.py`, so it is possible to link to the Python standard library documentation.
* A new `exceptions` module was added with a new exception class `InvalidErrorFormat`, to avoid circular imports from `config` and `violations`.
