### PR TITLE
Strip whitespace in _fix_set_options

### DIFF
--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -465,10 +465,10 @@ class ConfigurationParser(object):
         def _get_set(value_str):
             """Split `value_str` by the delimiter `,` and return a set.
 
-            Removes any occurrences of '' in the set.
+            Removes empty values ('') and strips whitespace.
 
             """
-            return set(value_str.split(',')) - {''}
+            return set([x.strip() for x in value_str.split(',')]) - {''}
 
         for opt in optional_set_options:
             value = getattr(options, opt)


### PR DESCRIPTION
This allows to specify e.g. "ignore" on multiple lines, without adding
additional commas:

    [pydocstyle]
    ignore = D100,D101,D102,D103,
      # "1 blank line required before class docstring"
      # Disabled by default, conflicts with D211.
      D203,
      # "Multi-line docstring summary should start at the second line" (vs. D212).
      D213,

Currently you would have to use:

    ignore = D100,
        ,D101,
        ,D102,

TODO:
 - [ ] doc
 - [ ] test