### PR TITLE
Drop pypy3 (temporarily)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ docs/_*
 
 # virtualenv
 venv/
+.venvs/
 
 # generated rst
 docs/snippets/error_code_table.rst

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,5 @@ matrix:
       env: TOXENV=py35
     - python: pypy
       env: TOXENV=pypy
-    - python: pypy3
-      env: TOXENV=pypy3
     - python: 2.7
       env: TOXENV=docs

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ docstring conventions.
 `PEP 257 <http://www.python.org/dev/peps/pep-0257/>`_ out of the box, but it
 should not be considered a reference implementation.
 
-**pydocstyle** supports Python 2.7, 3.3, 3.4, 3.5, pypy and pypy3.
+**pydocstyle** supports Python 2.7, 3.3, 3.4, 3.5 and pypy.
 
 Quick Start
 -----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ docstring conventions.
 `PEP 257 <http://www.python.org/dev/peps/pep-0257/>`_ out of the box, but it
 should not be considered a reference implementation.
 
-**pydocstyle** supports Python 2.7, 3.3, 3.4, 3.5, pypy and pypy3.
+**pydocstyle** supports Python 2.7, 3.3, 3.4, 3.5 and pypy.
 
 
 .. include:: quickstart.rst

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -10,6 +10,8 @@ Current Development Version
 Major Updates
 
 * Support for Python 2.6 has been dropped (#206, #217).
+* Support for PyPy3 2.6 has been temporarily dropped, until it will be
+  equivalent to CPython 3.3+ (#223).
 * Support for the ``pep257`` console script has been dropped. Only the
   ``pydocstyle`` console script should be used (#216, #218).
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33, py34, py35, pypy, pypy3, docs
+envlist = py27, py33, py34, py35, pypy, docs
 
 [testenv]
 # Make sure reading the UTF-8 from test.py works regardless of the locale used.


### PR DESCRIPTION
PyPy3 currently only implements the equivalent of CPython 3.2, which we don't support. Pip has also dropped support for PyPy3, resulting in the following build error:

```
/home/travis/virtualenv/pypy3-2.4.0/site-packages/virtualenv_support/pip-9.0.1-py2.py3-none-any.whl/pip/_vendor/pkg_resources/__init__.py:83: UserWarning: Support for Python 3.0-3.2 has been dropped. Future versions will fail here.
pip requires Python '>=2.6,!=3.0.*,!=3.1.*,!=3.2.*' but the running Python is 3.2.5
```

Support for PyPy3 will be restored when it is supported by Pip, and when it will implement a newer equivalent version for CPython (3.3 or higher).