### PR TITLE
Add check for 79 character line length

### DIFF
--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -235,6 +235,19 @@ class ConventionChecker(object):
                     yield violations.D207()
 
     @check_for(Definition)
+    def check_length(self, definition, docstring):
+        """D216: The length of the docstring should be under 79 chars.
+
+        The docstring must not exceed 79 characters.
+
+        """
+        if docstring:
+            lines = ast.literal_eval(docstring).split('\n')
+            lengths = [len(l) for l in lines if not is_blank(l)]
+            if max(lengths) > 79:
+                return violations.D216()
+
+    @check_for(Definition)
     def check_newline_after_last_paragraph(self, definition, docstring):
         """D209: Put multi-line docstring closing quotes on separate line.
 

--- a/src/pydocstyle/violations.py
+++ b/src/pydocstyle/violations.py
@@ -191,6 +191,7 @@ D213 = D2xx.create_error('D213', 'Multi-line docstring summary should start '
 D214 = D2xx.create_error('D214', 'Section is over-indented', '{0!r}')
 D215 = D2xx.create_error('D215', 'Section underline is over-indented',
                          'in section {0!r}')
+D216 = D2xx.create_error('D216', 'Line exceeds defined maximum length')
 
 D3xx = ErrorRegistry.create_group('D3', 'Quotes Issues')
 D300 = D3xx.create_error('D300', 'Use """triple double quotes"""',
@@ -235,5 +236,6 @@ conventions = AttrDict({
     'pep257': all_errors - {'D203', 'D212', 'D213', 'D214', 'D215', 'D404',
                             'D405', 'D406', 'D407', 'D408', 'D409', 'D410',
                             'D411'},
-    'numpy': all_errors - {'D203', 'D212', 'D213', 'D402'}
+    'numpy': all_errors - {'D203', 'D212', 'D213', 'D402'},
+    'pep8': all_errors - {'D216'}
 })

--- a/src/tests/test_cases/sections.py
+++ b/src/tests/test_cases/sections.py
@@ -114,6 +114,16 @@ def section_underline_overindented():
 
 
 @expect(_D213)
+@expect("D216: Line exceeds defined maximum length")
+def section_line_too_long():
+    """Valid headline.
+
+    This is the function's description, which is much longer than the 80 characters
+
+    """
+
+
+@expect(_D213)
 def ignore_non_actual_section():
     """Valid headline.
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ commands=sphinx-build -b html . _build
 [pytest]
 pep8ignore =
     test.py E701 E704
+    sections.py E501
 norecursedirs = docs .tox
 addopts = -rw
 


### PR DESCRIPTION
This is a pull request from #228 

This is really a PEP8 conformance, and even then this isn't checking strict conformance (72 character doc strings), but I thought maybe 79 character length strings wouldn't be to controversial.