### PR TITLE
Support custom config file path via '--config' CLI option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ docs/_*
 
 # virtualenv
 venv/
+.venv/
 .venvs/
 
 # generated rst

--- a/docs/snippets/cli.rst
+++ b/docs/snippets/cli.rst
@@ -15,6 +15,7 @@ Usage
       -d, --debug           print debug information
       -v, --verbose         print status information
       --count               print total number of errors to stdout
+      --config=<path>       specify a custom config file location
       --select=<codes>      choose the basic list of checked errors by specifying
                             which errors to check for (with a list of comma-
                             separated error codes or prefixes). for example:

--- a/docs/snippets/config.rst
+++ b/docs/snippets/config.rst
@@ -12,6 +12,9 @@ file specified above *in that exact order*. If a configuration file was not
 found, it keeps looking for one up the directory tree until one is found or
 uses the default configuration.
 
+``pydocstyle`` also accepts a ``--config`` CLI option to specify the path to a
+custom config file location.
+
 .. note::
 
     For backwards compatibility purposes, **pydocstyle** supports configuration

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -208,7 +208,10 @@ class ConfigurationParser(object):
         if path in self._cache:
             return self._cache[path]
 
-        config_file = self._get_config_file_in_folder(path)
+        if self._options.config_file:
+            config_file = os.path.abspath(self._options.config_file)
+        else:
+            config_file = self._get_config_file_in_folder(path)
 
         if config_file is None:
             parent_dir, tail = os.path.split(path)
@@ -257,6 +260,9 @@ class ConfigurationParser(object):
         parser = RawConfigParser()
         options = None
         should_inherit = True
+
+        if not os.path.isfile(path):
+            self._parser.error("Config file not found: {}".format(path))
 
         if parser.read(path) and self._get_section_name(parser):
             option_list = dict([(o.dest, o.type or o.action)
@@ -509,6 +515,8 @@ class ConfigurationParser(object):
                help='print status information')
         option('--count', action='store_true', default=False,
                help='print total number of errors to stdout')
+        option('--config', metavar='<path>', dest='config_file',
+               help='specify a custom config file location')
 
         # Error check options
         option('--select', metavar='<codes>', default=None,


### PR DESCRIPTION
Closes https://github.com/PyCQA/pydocstyle/issues/117

This is based on the work by @milkey-mouse (Thanks!) in https://github.com/PyCQA/pydocstyle/pull/208 and supersedes it.