### PR TITLE
Allow file extensions on config files

### DIFF
--- a/docs/snippets/config.rst
+++ b/docs/snippets/config.rst
@@ -5,7 +5,9 @@ options, and have a ``[pydocstyle]`` section.
 * ``setup.cfg``
 * ``tox.ini``
 * ``.pydocstyle``
+* ``.pydocstyle.ini``
 * ``.pydocstylerc``
+* ``.pydocstylerc.ini``
 
 When searching for a configuration file, ``pydocstyle`` looks for one of the
 file specified above *in that exact order*. If a configuration file was not

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -77,7 +77,9 @@ class ConfigurationParser(object):
         'setup.cfg',
         'tox.ini',
         '.pydocstyle',
+        '.pydocstyle.ini',
         '.pydocstylerc',
+        '.pydocstylerc.ini',
         # The following is deprecated, but remains for backwards compatibility.
         '.pep257',
     )


### PR DESCRIPTION
Supporting configuration files with the `.ini` extension means that many editors will support syntax highlighting out-of-the-box without needing an additional plugin or settings tweak.