### PR TITLE
Include documentation and tests in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,9 @@
+# include meta data
 include README.rst LICENSE-MIT
+# include documentation and files needed by documentation
+recursive-include docs *.py *.rst
+include docs/Makefile docs/make.bat
+# include tests and files needed by tests
+include tox.ini
+recursive-include requirements *.txt
+recursive-include src/tests *.py

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,15 @@ Release Notes
 **pydocstyle** version numbers follow the
 `Semantic Versioning <http://semver.org/>`_ specification.
 
+Current Development Version
+----------------------------
+
+Bug fixes
+
+* Include documentation and all files needed for building it in source
+  distribution.
+* Include tests and all files needed for running them in source distribution.
+
 2.0.0 - April 18th, 2017
 ------------------------
 


### PR DESCRIPTION
This will make the source distribution on PyPI (e.g.: [pydocstyle-2.0.0.zip](https://pypi.python.org/packages/b0/33/52e2fa5662fbb2a8bc9bdfe31327cd58c2f856b31851b73fc5baf86a2a14/pydocstyle-2.0.0.zip#md5=2be57712e2743d23949bafed957d8c86)) complete and stand-alone.

Also, this would be very useful for distribution packages of pydocstyle since one could run the tests against the currently installed version of pydocstyle while building the package.

In addition, one could also build and include the documentation if desired.

For a wider perspective, see [my Fedora review request for pydocstyle](https://bugzilla.redhat.com/show_bug.cgi?id=1409654).