### PR TITLE
reStructuredText (RST) validation of docstrings

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,1 +1,2 @@
 snowballstemmer==1.2.1
+docutils>=0.11,<1.0

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -13,7 +13,7 @@ from .config import IllegalConfiguration
 from .parser import (Package, Module, Class, NestedClass, Definition, AllError,
                      Method, Function, NestedFunction, Parser, StringIO,
                      ParseError)
-from .utils import log, is_blank, pairwise
+from .utils import log, is_blank, pairwise, rst_lint
 from .wordlists import IMPERATIVE_VERBS, IMPERATIVE_BLACKLIST, stem
 
 
@@ -641,6 +641,19 @@ class ConventionChecker(object):
                                      b is None)
             for err in self._check_section(docstring, definition, new_ctx):
                 yield err
+
+    @check_for(Definition)
+    def check_valid_rst(self, definition, docstring):
+        """D415: Fails reStructuredText validation.
+
+        PEP-287 recommends reStructuredText (RST) as the docstring markup
+        format, and this checks the docstring passes validation as RST.
+
+        Extract the docstring, remove the indentation as per the trim
+        function define in PEP-257, then validate it as RST.
+        """
+        if docstring:
+            return [violations.D415(_) for _ in rst_lint(docstring)]
 
 
 parse = Parser()

--- a/src/pydocstyle/utils.py
+++ b/src/pydocstyle/utils.py
@@ -6,6 +6,9 @@ try:
 except ImportError:
     from itertools import izip_longest as zip_longest
 
+from docutils import utils
+from docutils.core import Publisher
+from docutils.nodes import Element
 
 # Do not update the version manually - it is managed by `bumpversion`.
 __version__ = '2.0.0'
@@ -25,3 +28,63 @@ def pairwise(iterable, default_value):
     a, b = tee(iterable)
     _ = next(b, default_value)
     return zip_longest(a, b, fillvalue=default_value)
+
+def rst_lint(docstring_content):
+    """Lint reStructuredText and return errors
+
+    :param string content: reStructuredText to be linted
+    :rtype list: List of errors. Each error will contain a line, message (error
+        message), and full message (error message + source lines)
+
+    Based on public domain code by Todd Wolfson in his tool restructuredtext-lint
+    https://github.com/twolfson/restructuredtext-lint/blob/master/restructuredtext_lint/lint.py
+    """
+    # Generate a new parser (copying `rst2html.py` flow)
+    pub = Publisher(None, None, None, settings=None)
+    pub.set_components('standalone', 'restructuredtext', 'pseudoxml')
+
+    # Configure publisher
+    # DEV: We cannot use `process_command_line` since it processes `sys.argv`
+    settings = pub.get_settings(halt_level=5)
+    pub.set_io()
+
+    # Prepare a document to parse on
+    # DEV: We avoid the `read` method because when `source` is `None`,
+    #      it attempts to read from `stdin`.
+    #      However, we already know our content.
+    # DEV: We create our document without `parse` because we need to
+    #      attach observer's before parsing
+    reader = pub.reader
+    document = utils.new_document(None, settings)
+
+    # Disable stdout
+    document.reporter.stream = None
+
+    # Collect errors via an observer
+    errors = []
+
+    def error_collector(data):
+        errors.append(Element.astext(data.children[0]).replace("\n", " "))
+
+    document.reporter.attach_observer(error_collector)
+
+    # Parse the content (and collect errors)
+    reader.parser.parse(docstring_content, document)
+    # Apply transforms (and more collect errors)
+    # DEV: We cannot use `apply_transforms` since it has
+    # `attach_observer` baked in. We want only our listener.
+    document.transformer.populate_from_components(
+        (pub.source, pub.reader, pub.reader.parser, pub.writer, pub.destination)
+    )
+    transformer = document.transformer
+    while transformer.transforms:
+        if not transformer.sorted:
+            # Unsorted initially, and whenever a transform is added.
+            transformer.transforms.sort()
+            transformer.transforms.reverse()
+            transformer.sorted = 1
+        priority, transform_class, pending, kwargs = transformer.transforms.pop()
+        transform = transform_class(transformer.document, startnode=pending)
+        transform.apply(**kwargs)
+        transformer.applied.append((priority, transform_class, pending, kwargs))
+    return errors

--- a/src/pydocstyle/violations.py
+++ b/src/pydocstyle/violations.py
@@ -230,6 +230,7 @@ D412 = D4xx.create_error('D412', 'No blank lines allowed between a section '
 D413 = D4xx.create_error('D413', 'Missing blank line after last section',
                          '{0!r}')
 D414 = D4xx.create_error('D414', 'Section has no content', '{0!r}')
+D415 = D4xx.create_error('D415', 'Fails reStructuredText validation', '{0}')
 
 
 class AttrDict(dict):
@@ -241,6 +242,6 @@ all_errors = set(ErrorRegistry.get_error_codes())
 conventions = AttrDict({
     'pep257': all_errors - {'D203', 'D212', 'D213', 'D214', 'D215', 'D404',
                             'D405', 'D406', 'D407', 'D408', 'D409', 'D410',
-                            'D411'},
-    'numpy': all_errors - {'D203', 'D212', 'D213', 'D402', 'D413'}
+                            'D411', 'D415'},
+    'numpy': all_errors - {'D203', 'D212', 'D213', 'D402', 'D413', 'D415'}
 })


### PR DESCRIPTION
See #245. This is a proof of principle implementation to perform markup validation of docstrings as reStructuredText using docutils, based on public domain code by Todd Wolfson in his tool restructuredtext-lint ,
https://github.com/twolfson/restructuredtext-lint/blob/master/restructuredtext_lint/lint.py

Is something like this considered in scope for ``pydocstyle``?

If so, I'd personally prefer adding unique codes for each RST issue (perhaps numbered R### or D5## as a new class), rather than all under D415 as done here.