### PR TITLE
Fix --source option

### DIFF
--- a/src/pydocstyle/violations.py
+++ b/src/pydocstyle/violations.py
@@ -59,9 +59,8 @@ class Error(object):
         numbers_width = len(str(numbers_width))
         numbers_width = 6
         for n, line in enumerate(lines_stripped):
-            source += '{{}}{}: {{}}'.format(numbers_width).format(
+            source += '{{:{}}}: {{}}'.format(numbers_width).format(
                 n + offset, line)
-            source += '%*d: %s' % (numbers_width, n + offset, line)
             if n > 5:
                 source += '        ...\n'
                 break


### PR DESCRIPTION
This fixes the erroneous output described in https://github.com/PyCQA/pydocstyle/issues/256.

Perhaps someone else can decide if the line numbers displayed by `--source` should be of fixed width (in which case lines https://github.com/PyCQA/pydocstyle/blob/master/src/pydocstyle/violations.py#L56-L59 can be removed) or not (in which case line https://github.com/PyCQA/pydocstyle/blob/master/src/pydocstyle/violations.py#L60 can be removed).