### PR TITLE
Mark missing docstrings for nested classes as violation D106

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,14 @@ Release Notes
 **pydocstyle** version numbers follow the
 `Semantic Versioning <http://semver.org/>`_ specification.
 
+2.0.1 - Unreleased
+------------------------
+
+New Features
+
+* Public nested classes missing a docstring are now reported as D106 instead
+  of D101 (#198, #261).
+
 2.0.0 - April 18th, 2017
 ------------------------
 

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -114,7 +114,7 @@ class ConventionChecker(object):
                 docstring and is_blank(ast.literal_eval(docstring))):
             codes = {Module: violations.D100,
                      Class: violations.D101,
-                     NestedClass: violations.D101,
+                     NestedClass: violations.D106,
                      Method: (lambda: violations.D105() if definition.is_magic
                               else violations.D102()),
                      Function: violations.D103,

--- a/src/pydocstyle/violations.py
+++ b/src/pydocstyle/violations.py
@@ -160,6 +160,7 @@ D102 = D1xx.create_error('D102', 'Missing docstring in public method')
 D103 = D1xx.create_error('D103', 'Missing docstring in public function')
 D104 = D1xx.create_error('D104', 'Missing docstring in public package')
 D105 = D1xx.create_error('D105', 'Missing docstring in magic method')
+D106 = D1xx.create_error('D106', 'Missing docstring in public nested class')
 
 D2xx = ErrorRegistry.create_group('D2', 'Whitespace Issues')
 D200 = D2xx.create_error('D200', 'One-line docstring should fit on one line '

--- a/src/tests/test_cases/nested_class.py
+++ b/src/tests/test_cases/nested_class.py
@@ -10,12 +10,13 @@ expect('PublicClass', 'D101: Missing docstring in public class')
 
 class PublicClass(object):
 
-    expect('PublicNestedClass', 'D101: Missing docstring in public class')
+    expect('PublicNestedClass',
+           'D106: Missing docstring in public nested class')
 
     class PublicNestedClass(object):
 
         expect('PublicNestedClassInPublicNestedClass',
-               'D101: Missing docstring in public class')
+               'D106: Missing docstring in public nested class')
 
         class PublicNestedClassInPublicNestedClass(object):
             pass

--- a/src/tests/test_cases/test.py
+++ b/src/tests/test_cases/test.py
@@ -14,7 +14,7 @@ expect('class_', 'D101: Missing docstring in public class')
 
 class class_:
 
-    expect('meta', 'D101: Missing docstring in public class')
+    expect('meta', 'D106: Missing docstring in public nested class')
 
     class meta:
         """"""


### PR DESCRIPTION
Currently D101 covers both classes and nested classes. This is a problem if you want to exclude e.g. a Meta nested class from needing a docstring.
In this pull request I put Nested Classes that miss a docstring under D106. This allows me to configure pydocstyle to check for D101, but exclude the D106 situation.

This problem is also discussed at: https://github.com/PyCQA/pydocstyle/issues/198