### PR TITLE
Default value for breaking API change.

### DIFF
--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -60,7 +60,7 @@ class ConventionChecker(object):
                      'Attributes',
                      'Methods']
 
-    def check_source(self, source, filename, ignore_decorators):
+    def check_source(self, source, filename, ignore_decorators=None):
         module = parse(StringIO(source), filename)
         for definition in module:
             for this_check in self.checks:


### PR DESCRIPTION
Some tools like prospector tried to import a v1 pydocstyle or a v2 pydocstyle and
uses them the same way, BUT there has been a breaking change introduced here and so
`ignore_decorators` must be provided. This breaks at least prospectors behavior. 

May we set just a default=None value to have the same signature for the v1 and v2 function here.