### PR TITLE
Support stdin via hyphen as filename.

### DIFF
--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -696,8 +696,12 @@ def check(filenames, select=None, ignore=None, ignore_decorators=None):
     for filename in filenames:
         log.info('Checking file %s.', filename)
         try:
-            with tokenize_open(filename) as file:
-                source = file.read()
+            if filename == '-':
+                source = sys.stdin.read()
+                filename = "stdin"
+            else:
+                with tokenize_open(filename) as file:
+                    source = file.read()
             for error in ConventionChecker().check_source(source, filename,
                                                           ignore_decorators):
                 code = getattr(error, 'code', None)

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -171,7 +171,7 @@ class ConfigurationParser(object):
                 config = self._get_config(name)
                 match, _ = _get_matches(config)
                 ignore_decorators = _get_ignore_decorators(config)
-                if match(name):
+                if match(name) or name == '-':
                     yield (name, list(config.checked_codes), ignore_decorators)
 
     # --------------------------- Private Methods -----------------------------


### PR DESCRIPTION
Originally, I was looking to use pydocstyle in vim without using other plugins, and couldn't find a good way to pipe stdin. Eventually noticed that this was raised already in [issues/195](https://github.com/PyCQA/pydocstyle/issues/195). Proposed behavior is to use `-` as a 'filename' argument to notify that stdin is being piped. This might be too hacky, feel free to decline if this is the case!