### PR TITLE
Introduce D107 code for missing __init__ docstring

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -12,6 +12,8 @@ New Features
 
 * Public nested classes missing a docstring are now reported as D106 instead
   of D101 (#198, #261).
+* ``__init__`` methods missing a docstring are now reported as D107 instead of
+  D102 (#273).
 * Added support for Python 3.6 (#270).
 
 Bug Fixes

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,7 +13,7 @@ New Features
 * Public nested classes missing a docstring are now reported as D106 instead
   of D101 (#198, #261).
 * ``__init__`` methods missing a docstring are now reported as D107 instead of
-  D102 (#273).
+  D102 (#273, #277).
 * Added support for Python 3.6 (#270).
 
 Bug Fixes

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -116,7 +116,8 @@ class ConventionChecker(object):
                      Class: violations.D101,
                      NestedClass: violations.D106,
                      Method: (lambda: violations.D105() if definition.is_magic
-                              else (violations.D107() if definition.name == '__init__' else violations.D102())),
+                              else (violations.D107() if definition.is_init
+                              else violations.D102())),
                      Function: violations.D103,
                      NestedFunction: violations.D103,
                      Package: violations.D104}

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -116,7 +116,7 @@ class ConventionChecker(object):
                      Class: violations.D101,
                      NestedClass: violations.D106,
                      Method: (lambda: violations.D105() if definition.is_magic
-                              else violations.D102()),
+                              else (violations.D107() if definition.name == '__init__' else violations.D102())),
                      Function: violations.D103,
                      NestedFunction: violations.D103,
                      Package: violations.D104}

--- a/src/pydocstyle/parser.py
+++ b/src/pydocstyle/parser.py
@@ -167,6 +167,11 @@ class Method(Function):
                 self.name not in VARIADIC_MAGIC_METHODS)
 
     @property
+    def is_init(self):
+        """Return True iff this method is `__init__`."""
+        return self.name == '__init__'
+
+    @property
     def is_public(self):
         """Return True iff this method should be considered public."""
         # Check if we are a setter/deleter method, and mark as private if so.

--- a/src/pydocstyle/violations.py
+++ b/src/pydocstyle/violations.py
@@ -159,6 +159,7 @@ D103 = D1xx.create_error('D103', 'Missing docstring in public function')
 D104 = D1xx.create_error('D104', 'Missing docstring in public package')
 D105 = D1xx.create_error('D105', 'Missing docstring in magic method')
 D106 = D1xx.create_error('D106', 'Missing docstring in public nested class')
+D107 = D1xx.create_error('D107', 'Missing docstring in __init__')
 
 D2xx = ErrorRegistry.create_group('D2', 'Whitespace Issues')
 D200 = D2xx.create_error('D200', 'One-line docstring should fit on one line '

--- a/src/tests/test_cases/test.py
+++ b/src/tests/test_cases/test.py
@@ -26,7 +26,7 @@ class class_:
     def _ok_since_private():
         pass
 
-    @expect('D102: Missing docstring in public method')
+    @expect('D107: Missing docstring in __init__')
     def __init__(self=None):
         pass
 

--- a/src/tests/test_cases/test.py
+++ b/src/tests/test_cases/test.py
@@ -26,6 +26,10 @@ class class_:
     def _ok_since_private():
         pass
 
+    @expect('D102: Missing docstring in public method')
+    def __new__(self=None):
+        pass
+
     @expect('D107: Missing docstring in __init__')
     def __init__(self=None):
         pass


### PR DESCRIPTION
As described in #273, it would be useful to have a separate error code for missing docstrings on `__init__` methods (which currently fall under `D102`).
This PR introduces `D107` for this purpose.

This enables the user to use only class docstrings (as described by [this Google style](https://github.com/sphinx-doc/sphinx/blob/1.6.3/doc/ext/example_google.py#L201-L205)) by ignoring `D107`.