### PR TITLE
Print a warning where error code (/prefix) doesn't exist, e.g., --select=D9

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,6 +13,8 @@ New Features
 * Public nested classes missing a docstring are now reported as D106 instead
   of D101 (#198, #261).
 * Added support for Python 3.6 (#270).
+* Specifying an invalid error code prefix (e.g., ``--select=D9``) will print
+  a warning message to ``stderr`` (#253, #279).
 
 Bug Fixes
 

--- a/src/pydocstyle/cli.py
+++ b/src/pydocstyle/cli.py
@@ -90,5 +90,7 @@ def setup_stream_handlers(conf):
     log.addHandler(stdout_handler)
 
     stderr_handler = logging.StreamHandler(sys.stderr)
+    msg_format = "%(levelname)s: %(message)s"
+    stderr_handler.setFormatter(logging.Formatter(fmt=msg_format))
     stderr_handler.setLevel(logging.WARNING)
     log.addHandler(stderr_handler)

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -414,7 +414,9 @@ def test_bad_wildcard_add_ignore_cli(env):
     assert code == 1
     assert 'D203' in out
     assert 'D300' in out
-    assert 'D3034' not in out
+    assert 'D3004' not in out
+    assert ('Error code passed is not a prefix of any known errors: D3004'
+            in err)
 
 
 def test_conflicting_select_ignore_config(env):


### PR DESCRIPTION
Solves #253.
### To Do
- [x] Add unit tests and integration tests where applicable.  
- [x] Add a line to the release notes.
