### PR TITLE
Update information on pep257 & numpy conventions

### DIFF
--- a/docs/error_codes.rst
+++ b/docs/error_codes.rst
@@ -21,8 +21,9 @@ The numpy convention checks for all of the above errors except for
 D107, D203, D212, D213, D402, and D413.
 
 These conventions may be specified using `--convention=<name>` when
-running pydocstyle from the command line, or by specifying the
-convention in a configuration file.
+running pydocstyle from the command line or by specifying the
+convention in a configuration file.  See the :ref:`cli_usage` section
+for more details.
 
 Publicity
 ---------

--- a/docs/error_codes.rst
+++ b/docs/error_codes.rst
@@ -6,17 +6,23 @@ Grouping
 
 .. include:: snippets/error_code_table.rst
 
+Default conventions
+-------------------
 
-Default Checks
---------------
+Not all error codes are checked for by default.  There are two
+conventions that may be used by pydocstyle: pep257 and numpy.
 
-Not all error codes are checked for by default. The default behavior is to
-check only error codes that are part of the `PEP257
-<http://www.python.org/dev/peps/pep-0257/>`_ official convention.
+The pep257 convention, which is enabled by default in pydocstyle,
+checks for all of the above errors except for D203, D212, D213, D214,
+D215, D404, D405, D406, D407, D408, D409, D410, and D411 (as specified
+in `PEP257 <http://www.python.org/dev/peps/pep-0257/>`_).
 
-All of the above error codes are checked for by default except for D203,
-D212, D213 and D404.
+The numpy convention checks for all of the above errors except for
+D107, D203, D212, D213, D402, and D413.
 
+These conventions may be specified using `--convention=<name>` when
+running pydocstyle from the command line, or by specifying the
+convention in a configuration file.
 
 Publicity
 ---------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,7 +11,7 @@ New features
 
 * Violations are now reported on the line where the docstring starts, not the
   line of the ``def``/``class`` it corresponds to (#238, #83).
-* Updated description of pep257 and numpy conventions.
+* Updated description of pep257 and numpy conventions (#300).
 
 
 2.1.1 - October 9th, 2017

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,6 +11,7 @@ New features
 
 * Violations are now reported on the line where the docstring starts, not the
   line of the ``def``/``class`` it corresponds to (#238, #83).
+* Updated description of pep257 and numpy conventions.
 
 
 2.1.1 - October 9th, 2017


### PR DESCRIPTION
The file `error_codes.rst` had information that specified the pep257 default convention, but lacked information about the numpy convention.  I updated this section of the docs with the conventions specified at the end of `src/pydocstyle/violations.py`, which presently are:

```Python
conventions = AttrDict({
    'pep257': all_errors - {'D203', 'D212', 'D213', 'D214', 'D215', 'D404',
                            'D405', 'D406', 'D407', 'D408', 'D409', 'D410',
                            'D411'},
    'numpy': all_errors - {'D107', 'D203', 'D212', 'D213', 'D402', 'D413'}
})
```