### PR TITLE
Avoid error on use of __all__ variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+.pytest_cache
 
 # Translations
 *.mo

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -12,6 +12,8 @@ New features
 * Violations are now reported on the line where the docstring starts, not the
   line of the ``def``/``class`` it corresponds to (#238, #83).
 * Updated description of pep257 and numpy conventions (#300).
+* Referencing the ``__all__`` variable later in a module no longer
+  causes parse errors (#297, #308).
 
 
 2.1.1 - October 9th, 2017

--- a/src/pydocstyle/parser.py
+++ b/src/pydocstyle/parser.py
@@ -442,6 +442,8 @@ class Parser(object):
         assert self.current.value == '__all__'
         self.consume(tk.NAME)
         if self.current.value != '=':
+            if self.all is not None:
+                return
             raise AllError('Could not evaluate contents of __all__. ')
         self.consume(tk.OP)
         if self.current.value not in '([':

--- a/src/tests/parser_test.py
+++ b/src/tests/parser_test.py
@@ -514,6 +514,21 @@ def test_complex_module():
     assert len(list(module)) == 8
 
 
+def test_module_checks_all():
+    """Test that a complex module is parsed correctly."""
+    parser = Parser()
+    code = CodeSnippet('''\
+        """Module."""
+        __all__ = ['f']
+        def f():
+            """Foo the Bar."""
+            pass
+        assert 'f' in __all__
+    ''')
+
+    parser.parse(code, "filepath")
+
+
 @pytest.mark.parametrize("code", (
     CodeSnippet("""\
         __all__ = ['foo', 'bar']


### PR DESCRIPTION
This is a pretty simple change, but allows `pydocstyle` to run on modules that check the `__all__` variable later (simple example in the test case; more complex in Hypothesis).  Closes #297.