### PR TITLE
WIP: run checks in parallel

### DIFF
--- a/src/pydocstyle/parser.py
+++ b/src/pydocstyle/parser.py
@@ -231,6 +231,9 @@ class Docstring(str):
         self.start = start
         self.end = end
 
+    def __getnewargs__(self):
+        return (str(self), self.start, self.end)
+
 
 VARIADIC_MAGIC_METHODS = ('__init__', '__call__', '__new__')
 


### PR DESCRIPTION
Using multiprocessing.Pool to run tests in parallel. For me, it cut the time to run pydocstyle from 30 seconds to 5.

WIP because I don't think this should be the default mode, but wasn't sure what would be good configuration/command line flags to use.
