### PR TITLE
Fix false-positive D405 recognition

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -19,8 +19,8 @@ New features
 
 Bug Fixes
 
-* Fixed a false-positive recognition of section names causing D405 to be thrown
-  (#311, #317).
+* Fixed a false-positive recognition of section names causing D405 to be
+  reported (#311, #317).
 
 
 2.1.1 - October 9th, 2017

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -17,6 +17,10 @@ New features
   line of the ``def``/``class`` it corresponds to (#238, #83).
 * Updated description of pep257 and numpy conventions (#300).
 
+Bug Fixes
+
+* Fixed a false-positive recognition of section names causing D405 to be thrown
+
 
 2.1.1 - October 9th, 2017
 -------------------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -20,6 +20,7 @@ New features
 Bug Fixes
 
 * Fixed a false-positive recognition of section names causing D405 to be thrown
+  (#311, #317).
 
 
 2.1.1 - October 9th, 2017

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -480,10 +480,7 @@ class ConventionChecker(object):
             context.section_name.strip()
         ).strip()
 
-        section_suffix_is_only_colon = (
-            section_name_suffix.startswith(':') and
-            is_blank(section_name_suffix[1:])
-        )
+        section_suffix_is_only_colon = section_name_suffix == ':'
 
         punctuation = [',', ';', '.', '-', '\\', '/', ']', '}', ')']
         prev_line_ends_with_punctuation = \

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -436,6 +436,7 @@ class ConventionChecker(object):
 
         For example, if `line` is "  Hello world!!!", returns "Hello world".
         """
+        result = re("[\w ]+").match(line.strip())
         if result is not None:
             return result.group()
 

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -436,7 +436,6 @@ class ConventionChecker(object):
 
         For example, if `line` is "  Hello world!!!", returns "Hello world".
         """
-        result = re("[A-Za-z ]+").match(line.strip())
         if result is not None:
             return result.group()
 
@@ -625,7 +624,7 @@ class ConventionChecker(object):
                                                        'is_last_section'))
 
         # First - create a list of possible contexts. Note that the
-        # `following_linex` member is until the end of the docstring.
+        # `following_lines` member is until the end of the docstring.
         contexts = (SectionContext(self._get_leading_words(lines[i].strip()),
                                    lines[i - 1],
                                    lines[i],

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -476,9 +476,8 @@ class ConventionChecker(object):
         If one of the conditions is true, we will consider the line as
         a section name.
         """
-        section_name_suffix = context.line.strip().lstrip(
-            context.section_name.strip()
-        ).strip()
+        section_name_suffix = \
+            context.line.strip().lstrip(context.section_name.strip()).strip()
 
         section_suffix_is_only_colon = section_name_suffix == ':'
 
@@ -486,10 +485,14 @@ class ConventionChecker(object):
         prev_line_ends_with_punctuation = \
             any(context.previous_line.strip().endswith(x) for x in punctuation)
 
-        return ((is_blank(section_name_suffix) or
-                 section_suffix_is_only_colon) and
-                (prev_line_ends_with_punctuation or
-                 is_blank(context.previous_line)))
+        this_line_looks_like_a_section_name = \
+            is_blank(section_name_suffix) or section_suffix_is_only_colon
+        
+        prev_line_looks_like_end_of_paragraph = \
+            prev_line_ends_with_punctuation or is_blank(context.previous_line)
+
+        return (this_line_looks_like_a_section_name and
+                prev_line_looks_like_end_of_paragraph)
 
     @classmethod
     def _check_section_underline(cls, section_name, context, indentation):

--- a/src/tests/test_cases/sections.py
+++ b/src/tests/test_cases/sections.py
@@ -215,3 +215,14 @@ def multiple_sections():
     My attention.
 
     """
+
+
+@expect(_D213)
+def false_positive_section_prefix():
+    """Toggle the gizmo.
+
+    Arguments
+    ---------
+        attributes_are_fun: attributes for the function.
+
+    """

--- a/src/tests/test_cases/sections.py
+++ b/src/tests/test_cases/sections.py
@@ -221,8 +221,22 @@ def multiple_sections():
 def false_positive_section_prefix():
     """Toggle the gizmo.
 
-    Arguments
-    ---------
-        attributes_are_fun: attributes for the function.
+    Parameters
+    ----------
+    attributes_are_fun: attributes for the function.
+
+    """
+
+
+@expect(_D213)
+def section_names_as_parameter_names():
+    """Toggle the gizmo.
+
+    Parameters
+    ----------
+    notes : list
+        A list of wonderful notes.
+    examples: list
+        A list of horrible examples.
 
     """

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ envlist = {py27, py34, py35, py36, pypy}-{tests, install}, docs
 setenv =
     LANG=C
     LC_ALL=C
-commands = py.test --pep8 --cache-clear -vv src/tests
+# To pass arguments to py.test, use `tox [options] -- [pytest posargs]`.
+commands = py.test --pep8 --cache-clear -vv src/tests {posargs}
 deps =
     -rrequirements/runtime.txt
     -rrequirements/tests.txt


### PR DESCRIPTION
Solves #311.

The problem was that the regex split words when reached an underscore, so "arguments_bla" was caught as "arguments".