### PR TITLE
Fix a message template to accept vim's default errorformat.

### DIFF
--- a/src/pydocstyle/violations.py
+++ b/src/pydocstyle/violations.py
@@ -71,7 +71,7 @@ class Error(object):
     def __str__(self):
         self.explanation = '\n'.join(l for l in self.explanation.split('\n')
                                      if not is_blank(l))
-        template = '{filename}:{line} {definition}:\n        {message}'
+        template = '{filename}:{line}: {definition}:\n        {message}'
         if self.source and self.explain:
             template += '\n\n{explanation}\n\n{lines}\n'
         elif self.source and not self.explain:


### PR DESCRIPTION
Hi

This PR fix a message template to accept vim's default error format. 
I'm a vimmer, and use its [quickfix](https://vim-jp.org/vimdoc-en/quickfix.html) feature. 
This feature requires that error message formats of some tools(like pydocstyle) are in `errorformat` settings of vim. 
It's default settings support `%f:%l:%m`, but current format of pydocstyle is `%f:%l %m`(=lack of `:` after line number). 
Of course, we can change vim's `errorformat` settings, but I'm happy if I use default settings.

FYI: pycodestyle's format is in default `errorformat` settings.
https://github.com/PyCQA/pycodestyle/blob/master/pycodestyle.py#L107

Could you consider this change? Thanks!

=========

### Check

- [ ] Add unit tests and integration tests where applicable.  
       I'm sorry, but I can't find the best place to put tests checking error message format. Could you help it?

- [ ] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.