### PR TITLE
Drop support for Python 2.7 and PyPy

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,26 +1,16 @@
 environment:
   matrix:
-    - TOXENV: "py27-tests"
     - TOXENV: "py34-tests"
     - TOXENV: "py35-tests"
     - TOXENV: "py36-tests"
     - TOXENV: "py37-tests"
     - TOXENV: "pypy-tests"
-    - TOXENV: "py27-install"
     - TOXENV: "py34-install"
     - TOXENV: "py35-install"
     - TOXENV: "py36-install"
     - TOXENV: "py37-install"
     - TOXENV: "pypy-install"
     - TOXENV: "docs"
-
-install:
-  # This takes a long time, so it's done only for pypy environments.
-  - ps: if($env:TOXENV -eq 'pypy-tests' -or $env:TOXENV -eq 'pypy-install') {
-          choco install python.pypy;
-        }
-
-  - pip install tox
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,9 @@ environment:
     - TOXENV: "py37-install"
     - TOXENV: "docs"
 
+install:
+  - pip install tox
+
 build: off
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,12 +4,10 @@ environment:
     - TOXENV: "py35-tests"
     - TOXENV: "py36-tests"
     - TOXENV: "py37-tests"
-    - TOXENV: "pypy-tests"
     - TOXENV: "py34-install"
     - TOXENV: "py35-install"
     - TOXENV: "py36-install"
     - TOXENV: "py37-install"
-    - TOXENV: "pypy-install"
     - TOXENV: "docs"
 
 build: off

--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,6 @@ pydocstyle - docstring style checker
     :target: https://pypi.org/project/pydocstyle
 
 
-(formerly pep257)
-
 **pydocstyle** is a static analysis tool for checking compliance with Python
 docstring conventions.
 
@@ -25,10 +23,7 @@ docstring conventions.
 `PEP 257 <http://www.python.org/dev/peps/pep-0257/>`_ out of the box, but it
 should not be considered a reference implementation.
 
-**pydocstyle** supports Python 2.7, 3.4, 3.5, 3.6, 3.7, and pypy.
-
-
-.. attention:: Support for Python 2.7 will be removed in the next release.
+**pydocstyle** supports Python 3.4, 3.5, 3.6 and 3.7.
 
 
 Quick Start

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,10 +8,7 @@ docstring conventions.
 `PEP 257 <http://www.python.org/dev/peps/pep-0257/>`_ out of the box, but it
 should not be considered a reference implementation.
 
-**pydocstyle** supports Python 2.7, 3.4, 3.5, 3.6, 3.7, and pypy.
-
-
-.. attention:: Support for Python 2.7 will be removed in the next release.
+**pydocstyle** supports Python 3.4, 3.5, 3.6, 3.7, and pypy.
 
 
 .. include:: quickstart.rst

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,7 +9,7 @@ Current Development Version
 
 Major Updates
 
-* Support for Python 2.x and PyPy has been dropped (#315, #316).
+* Support for Python 2.x and PyPy has been dropped (#340).
 
 3.0.0 - October 14th, 2018
 --------------------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,13 @@ Release Notes
 **pydocstyle** version numbers follow the
 `Semantic Versioning <http://semver.org/>`_ specification.
 
+Current Development Version
+---------------------------
+
+Major Updates
+
+* Support for Python 2.x and PyPy has been dropped (#315, #316).
+
 3.0.0 - October 14th, 2018
 --------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,6 @@ requirements = [
 ]
 
 
-# Python3 to Python2 backport support.
-if sys.version_info[0] == 2:
-    requirements.append('configparser')
-
-
 setup(
     name='pydocstyle',
     version=version,
@@ -30,8 +25,6 @@ setup(
         'Intended Audience :: Developers',
         'Environment :: Console',
         'Development Status :: 5 - Production/Stable',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tox.ini
+++ b/tox.ini
@@ -29,19 +29,19 @@ commands =
 
 [testenv:py34-install]
 skip_install = {[testenv:py37-install]skip_install}
-commands = {[testenv:py27-install]commands}
+commands = {[testenv:py37-install]commands}
 
 [testenv:py35-install]
 skip_install = {[testenv:py37-install]skip_install}
-commands = {[testenv:py27-install]commands}
+commands = {[testenv:py37-install]commands}
 
 [testenv:py36-install]
 skip_install = {[testenv:py37-install]skip_install}
-commands = {[testenv:py27-install]commands}
+commands = {[testenv:py37-install]commands}
 
 [testenv:pypy-install]
 skip_install = {[testenv:py37-install]skip_install}
-commands = {[testenv:py27-install]commands}
+commands = {[testenv:py37-install]commands}
 
 [testenv:docs]
 changedir=docs

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = {py27, py34, py35, py36, py37, pypy}-{tests, install}, docs
+envlist = {py34, py35, py36, py37}-{tests, install}, docs
 
 [testenv]
 # Make sure reading the UTF-8 from test.py works regardless of the locale used.
@@ -17,7 +17,7 @@ deps =
     -rrequirements/runtime.txt
     -rrequirements/tests.txt
 
-[testenv:py27-install]
+[testenv:py37-install]
 skip_install = True
 commands =
     python setup.py bdist_wheel
@@ -25,26 +25,22 @@ commands =
     pydocstyle --help
 
 # There's no way to generate sub-sections in tox.
-# The following sections are all references to the `py27-install`.
+# The following sections are all references to the `py37-install`.
 
 [testenv:py34-install]
-skip_install = {[testenv:py27-install]skip_install}
+skip_install = {[testenv:py37-install]skip_install}
 commands = {[testenv:py27-install]commands}
 
 [testenv:py35-install]
-skip_install = {[testenv:py27-install]skip_install}
+skip_install = {[testenv:py37-install]skip_install}
 commands = {[testenv:py27-install]commands}
 
 [testenv:py36-install]
-skip_install = {[testenv:py27-install]skip_install}
-commands = {[testenv:py27-install]commands}
-
-[testenv:py37-install]
-skip_install = {[testenv:py27-install]skip_install}
+skip_install = {[testenv:py37-install]skip_install}
 commands = {[testenv:py27-install]commands}
 
 [testenv:pypy-install]
-skip_install = {[testenv:py27-install]skip_install}
+skip_install = {[testenv:py37-install]skip_install}
 commands = {[testenv:py27-install]commands}
 
 [testenv:docs]


### PR DESCRIPTION
The next version of pydocstyle will support Python 3.4+ only. Support for PyPy3 should also be added to the next release in a different PR.

This PR only removes Python 2.7 from the docs and CI tools - the actual refactoring of the source code will happen over time (removing `six`, using Python 3 features, etc.)