### PR TITLE
Remove `six` from production code and other Python 2/3 compatibility imports

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ environment:
     - TOXENV: "py35-install"
     - TOXENV: "py36-install"
     - TOXENV: "py37-install"
-    - TOXENV: "docs"
+    - TOXENV: "py36-docs"
 
 install:
   - pip install tox

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,3 +2,4 @@ pytest==3.0.2
 pytest-pep8==1.0.6
 mock==2.0.0
 pathlib
+six

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ version = '3.0.1rc'
 
 requirements = [
     'snowballstemmer',
-    'six',
 ]
 
 

--- a/src/pydocstyle/__init__.py
+++ b/src/pydocstyle/__init__.py
@@ -3,5 +3,5 @@ from .violations import Error, conventions
 from .utils import __version__
 
 # Temporary hotfix for flake8-docstrings
-from .checker import ConventionChecker, tokenize_open
+from .checker import ConventionChecker
 from .parser import AllError

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -20,14 +20,6 @@ from .wordlists import IMPERATIVE_VERBS, IMPERATIVE_BLACKLIST, stem
 __all__ = ('check', )
 
 
-# If possible (python >= 3.2) use tokenize.open to open files, so PEP 263
-# encoding markers are interpreted.
-try:
-    tokenize_open = tk.open
-except AttributeError:
-    tokenize_open = open
-
-
 def check_for(kind, terminal=False):
     def decorator(f):
         f._check_for = kind
@@ -712,7 +704,7 @@ def check(filenames, select=None, ignore=None, ignore_decorators=None):
     for filename in filenames:
         log.info('Checking file %s.', filename)
         try:
-            with tokenize_open(filename) as file:
+            with tk.open(filename) as file:
                 source = file.read()
             for error in ConventionChecker().check_source(source, filename,
                                                           ignore_decorators):

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -5,10 +5,7 @@ import itertools
 import os
 from collections import namedtuple
 from re import compile as re
-
-
 from configparser import RawConfigParser
-
 
 from .utils import __version__, log
 from .violations import ErrorRegistry, conventions

--- a/src/pydocstyle/parser.py
+++ b/src/pydocstyle/parser.py
@@ -1,31 +1,12 @@
 """Python code parser."""
 
-import six
 import textwrap
 import tokenize as tk
 from itertools import chain, dropwhile
 from re import compile as re
+from io import StringIO
+
 from .utils import log
-
-try:
-    from StringIO import StringIO
-except ImportError:  # Python 3.0 and later
-    from io import StringIO
-
-try:
-    next
-except NameError:  # Python 2.5 and earlier
-    nothing = object()
-
-    def next(obj, default=nothing):
-        if default == nothing:
-            return obj.next()
-        else:
-            try:
-                return obj.next()
-            except StopIteration:
-                return default
-
 
 __all__ = ('Parser', 'Definition', 'Module', 'Package', 'Function',
            'NestedFunction', 'Method', 'Class', 'NestedClass', 'AllError',
@@ -325,7 +306,7 @@ class Parser(object):
         try:
             compile(src, filename, 'exec')
         except SyntaxError as error:
-            six.raise_from(ParseError(), error)
+            raise ParseError() from error
         self.stream = TokenStream(StringIO(src))
         self.filename = filename
         self.dunder_all = None

--- a/src/pydocstyle/utils.py
+++ b/src/pydocstyle/utils.py
@@ -1,10 +1,6 @@
 """General shared utilities."""
 import logging
-from itertools import tee
-try:
-    from itertools import zip_longest
-except ImportError:
-    from itertools import izip_longest as zip_longest
+from itertools import tee, zip_longest
 
 
 # Do not update the version manually - it is managed by `bumpversion`.

--- a/src/tests/parser_test.py
+++ b/src/tests/parser_test.py
@@ -1,13 +1,15 @@
 """Parser tests."""
 
+import io
 import six
 import sys
 import pytest
 import textwrap
+
 from pydocstyle.parser import Parser, ParseError
 
 
-class CodeSnippet(six.StringIO):
+class CodeSnippet(io.StringIO):
     """A code snippet.
 
     Automatically wraps snippet as a file-like object and handles line wraps.
@@ -16,7 +18,7 @@ class CodeSnippet(six.StringIO):
 
     def __init__(self, code_string):
         """Initialize the object."""
-        six.StringIO.__init__(self, textwrap.dedent(code_string))
+        io.StringIO.__init__(self, textwrap.dedent(code_string))
 
 
 def test_function():
@@ -423,7 +425,6 @@ def test_nested_class():
     assert str(inner_class) == 'in public nested class `InnerClass`'
 
 
-@pytest.mark.skipif(six.PY2, reason='`raise from` is invalid in Python 2.x')
 def test_raise_from():
     """Make sure 'raise x from y' doesn't trip the parser."""
     parser = Parser()
@@ -431,8 +432,6 @@ def test_raise_from():
     parser.parse(code, 'file_path')
 
 
-@pytest.mark.skipif(six.PY2, reason='Matrix multiplication operator is '
-                                    'invalid in Python 2.x')
 def test_simple_matrix_multiplication():
     """Make sure 'a @ b' doesn't trip the parser."""
     if sys.version_info.minor < 5:
@@ -445,8 +444,6 @@ def test_simple_matrix_multiplication():
     parser.parse(code, 'file_path')
 
 
-@pytest.mark.skipif(six.PY2, reason='Matrix multiplication operator is '
-                                    'invalid in Python 2.x')
 def test_matrix_multiplication_with_decorators():
     """Make sure 'a @ b' doesn't trip the parser."""
     if sys.version_info.minor < 5:

--- a/src/tests/test_decorators.py
+++ b/src/tests/test_decorators.py
@@ -2,11 +2,8 @@
 
 Use tox or py.test to run the test suite.
 """
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
+import io
 import textwrap
 
 from pydocstyle import parser, checker
@@ -25,7 +22,7 @@ class TestParser(object):
             class Foo:
                 pass
         """)
-        module = checker.parse(StringIO(code), 'dummy.py')
+        module = checker.parse(io.StringIO(code), 'dummy.py')
         decorators = module.children[0].decorators
 
         assert 1 == len(decorators)
@@ -45,7 +42,7 @@ class TestParser(object):
                 pass
         """)
 
-        module = checker.parse(StringIO(code), 'dummy.py')
+        module = checker.parse(io.StringIO(code), 'dummy.py')
         defined_class = module.children[0]
         decorators = defined_class.decorators
 
@@ -67,7 +64,7 @@ class TestParser(object):
                 class NestedClass:
                     pass
         """)
-        module = checker.parse(StringIO(code), 'dummy.py')
+        module = checker.parse(io.StringIO(code), 'dummy.py')
         nested_class = module.children[0].children[0]
         decorators = nested_class.decorators
 
@@ -84,7 +81,7 @@ class TestParser(object):
                     pass
         """)
 
-        module = checker.parse(StringIO(code), 'dummy.py')
+        module = checker.parse(io.StringIO(code), 'dummy.py')
         defined_class = module.children[0]
         decorators = defined_class.children[0].decorators
 
@@ -106,7 +103,7 @@ class TestParser(object):
                     pass
         """)
 
-        module = checker.parse(StringIO(code), 'dummy.py')
+        module = checker.parse(io.StringIO(code), 'dummy.py')
         defined_class = module.children[0]
         decorators = defined_class.children[0].decorators
 
@@ -126,7 +123,7 @@ class TestParser(object):
                 pass
         """)
 
-        module = checker.parse(StringIO(code), 'dummy.py')
+        module = checker.parse(io.StringIO(code), 'dummy.py')
         decorators = module.children[0].decorators
 
         assert 1 == len(decorators)
@@ -144,7 +141,7 @@ class TestParser(object):
                         pass
         """)
 
-        module = checker.parse(StringIO(code), 'dummy.py')
+        module = checker.parse(io.StringIO(code), 'dummy.py')
         defined_class = module.children[0]
         decorators = defined_class.children[0].children[0].decorators
 

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -173,7 +173,7 @@ def test_ignore_list():
     mock_open = mock.mock_open(read_data=function_to_check)
     from pydocstyle import checker
     with mock.patch.object(
-            checker, 'tokenize_open', mock_open, create=True):
+            checker.tk, 'open', mock_open, create=True):
         errors = tuple(checker.check(['filepath']))
         error_codes = {error.code for error in errors}
         assert error_codes == expected_error_codes
@@ -181,7 +181,7 @@ def test_ignore_list():
     # We need to recreate the mock, otherwise the read file is empty
     mock_open = mock.mock_open(read_data=function_to_check)
     with mock.patch.object(
-            checker, 'tokenize_open', mock_open, create=True):
+            checker.tk, 'open', mock_open, create=True):
         ignored = {'D100', 'D202', 'D213'}
         errors = tuple(checker.check(['filepath'], ignore=ignored))
         error_codes = {error.code for error in errors}


### PR DESCRIPTION
There's still `six` use in tests to check for Python 3.4.