### PR TITLE
Introducing type hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+.mypy_cache
 
 # Translations
 *.mo

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,3 +2,4 @@ pytest==3.0.2
 pytest-pep8==1.0.6
 mock==2.0.0
 pathlib
+mypy==0.630

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -25,7 +25,7 @@ __all__ = ('check', )
 try:
     tokenize_open = tk.open
 except AttributeError:
-    tokenize_open = open
+    tokenize_open = open  # type: ignore
 
 
 def check_for(kind, terminal=False):

--- a/src/pydocstyle/cli.py
+++ b/src/pydocstyle/cli.py
@@ -49,7 +49,7 @@ def run_pydocstyle():
         return ReturnCode.invalid_options
 
     count = 0
-    for error in errors:
+    for error in errors:  # type: ignore
         if hasattr(error, 'code'):
             sys.stdout.write('%s\n' % error)
         count += 1

--- a/src/pydocstyle/parser.py
+++ b/src/pydocstyle/parser.py
@@ -121,7 +121,7 @@ class Definition(Value):
 class Module(Definition):
     """A Python source code module."""
 
-    _fields = ('name', '_source', 'start', 'end', 'decorators', 'docstring',
+    _fields = ('name', '_source', 'start', 'end', 'decorators', 'docstring',  # type: ignore
                'children', 'parent', '_dunder_all', 'dunder_all_error',
                'future_imports', 'skipped_error_codes')
     _nest = staticmethod(lambda s: {'def': Function, 'class': Class}[s])

--- a/src/pydocstyle/utils.py
+++ b/src/pydocstyle/utils.py
@@ -4,7 +4,7 @@ from itertools import tee
 try:
     from itertools import zip_longest
 except ImportError:
-    from itertools import izip_longest as zip_longest
+    from itertools import izip_longest as zip_longest  # type: ignore
 
 
 # Do not update the version manually - it is managed by `bumpversion`.

--- a/src/pydocstyle/utils.py
+++ b/src/pydocstyle/utils.py
@@ -1,6 +1,7 @@
 """General shared utilities."""
 import logging
 from itertools import tee
+from typing import Iterable, Any, Tuple
 try:
     from itertools import zip_longest
 except ImportError:
@@ -8,16 +9,19 @@ except ImportError:
 
 
 # Do not update the version manually - it is managed by `bumpversion`.
-__version__ = '3.0.1rc'
+__version__: str = '3.0.1rc'
 log = logging.getLogger(__name__)
 
 
-def is_blank(string):
+def is_blank(string: str) -> bool:
     """Return True iff the string contains only whitespaces."""
     return not string.strip()
 
 
-def pairwise(iterable, default_value):
+def pairwise(
+    iterable: Iterable,
+    default_value: Any,
+) -> Iterable[Tuple[Any, Any]]:
     """Return pairs of items from `iterable`.
 
     pairwise([1, 2, 3], default_value=None) -> (1, 2) (2, 3), (3, None)

--- a/src/pydocstyle/violations.py
+++ b/src/pydocstyle/violations.py
@@ -92,7 +92,7 @@ class Error(object):
 class ErrorRegistry(object):
     """A registry of all error codes, divided to groups."""
 
-    groups = []
+    groups = []  # type: ignore
 
     class ErrorGroup(object):
         """A group of similarly themed errors."""

--- a/src/tests/test_cases/sections.py
+++ b/src/tests/test_cases/sections.py
@@ -48,7 +48,7 @@ def no_underline():
 
 @expect(_D213)
 @expect("D407: Missing dashed underline after section ('Returns')")
-def no_underline():
+def no_underline_and_no_description():
     """Toggle the gizmo.
 
     Returns

--- a/src/tests/test_cases/test.py
+++ b/src/tests/test_cases/test.py
@@ -20,10 +20,10 @@ class class_:
         """"""
 
     @expect('D102: Missing docstring in public method')
-    def method():
+    def method(self=None):
         pass
 
-    def _ok_since_private():
+    def _ok_since_private(self=None):
         pass
 
     @expect('D102: Missing docstring in public method')

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = {py34, py35, py36, py37}-{tests, install}, docs
+envlist = {py34,py35,py36,py37}-{tests,install},docs
 
 [testenv]
 # Make sure reading the UTF-8 from test.py works regardless of the locale used.

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,9 @@ setenv =
     LANG=C
     LC_ALL=C
 # To pass arguments to py.test, use `tox [options] -- [pytest posargs]`.
-commands = py.test --pep8 --cache-clear -vv src/tests {posargs}
+commands =
+    py.test --pep8 --cache-clear -vv src/tests {posargs}
+    mypy --config-file=tox.ini src/
 deps =
     -rrequirements/runtime.txt
     -rrequirements/tests.txt
@@ -64,3 +66,8 @@ addopts = -rw
 inherit = false
 convention = pep257
 add-select = D404
+
+[mypy]
+ignore_missing_imports = true
+strict_optional = true
+disallow_incomplete_defs = true


### PR DESCRIPTION
Added  the minimal code needed for typehint validation.
I also removed some whitespaces in tox.ini - it seems that tox doesn't remove them (for instance, py34 install env was called `py34- install`).