### PR TITLE
Refactor the checker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from __future__ import with_statement
-from setuptools import setup
+from setuptools import setup, find_packages
 import sys
 
 # Do not update the version manually - it is managed by `bumpversion`.
@@ -33,7 +33,7 @@ setup(
         'License :: OSI Approved :: MIT License',
     ],
     keywords='pydocstyle, PEP 257, pep257, PEP 8, pep8, docstrings',
-    packages=('pydocstyle',),
+    packages=find_packages('src', exclude=["tests", "tests.*"]),
     package_dir={'': 'src'},
     package_data={'pydocstyle': ['data/*.txt']},
     install_requires=requirements,

--- a/src/pydocstyle/__init__.py
+++ b/src/pydocstyle/__init__.py
@@ -1,4 +1,4 @@
-from pydocstyle.checker import check
+from pydocstyle.checker import check, check_source
 from pydocstyle.violations import Error, conventions
 from pydocstyle.utils import __version__
 

--- a/src/pydocstyle/__init__.py
+++ b/src/pydocstyle/__init__.py
@@ -1,7 +1,7 @@
-from .checker import check
-from .violations import Error, conventions
-from .utils import __version__
+from pydocstyle.checker import check
+from pydocstyle.violations import Error, conventions
+from pydocstyle.utils import __version__
 
 # Temporary hotfix for flake8-docstrings
-from .checker import ConventionChecker
-from .parser import AllError
+from pydocstyle.checker import ConventionChecker
+from pydocstyle.parser import AllError

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -1,31 +1,15 @@
 """Parsed source code checkers for docstring violations."""
 
-import ast
-import string
-import sys
 import tokenize as tk
-from itertools import takewhile
-from re import compile as re
-from collections import namedtuple
 
-from . import violations
-from .config import IllegalConfiguration
-from .parser import (Package, Module, Class, NestedClass, Definition, AllError,
-                     Method, Function, NestedFunction, Parser, StringIO,
-                     ParseError)
-from .utils import log, is_blank, pairwise
-from .wordlists import IMPERATIVE_VERBS, IMPERATIVE_BLACKLIST, stem
+from pydocstyle import violations
+from pydocstyle.checkers import get_checkers
+from pydocstyle.config import IllegalConfiguration
+from pydocstyle.parser import Parser, StringIO, ParseError, AllError
+from pydocstyle.utils import log
 
 
 __all__ = ('check', )
-
-
-def check_for(kind, terminal=False):
-    def decorator(f):
-        f._check_for = kind
-        f._terminal = terminal
-        return f
-    return decorator
 
 
 class ConventionChecker:
@@ -38,624 +22,57 @@ class ConventionChecker:
 
     """
 
-    SECTION_NAMES = ['Short Summary',
-                     'Extended Summary',
-                     'Parameters',
-                     'Returns',
-                     'Yields',
-                     'Other Parameters',
-                     'Raises',
-                     'See Also',
-                     'Notes',
-                     'References',
-                     'Examples',
-                     'Attributes',
-                     'Methods']
-
     def check_source(self, source, filename, ignore_decorators=None):
-        module = parse(StringIO(source), filename)
-        for definition in module:
-            for this_check in self.checks:
-                terminate = False
-                if isinstance(definition, this_check._check_for):
-                    skipping_all = (definition.skipped_error_codes == 'all')
-                    decorator_skip = ignore_decorators is not None and any(
-                        len(ignore_decorators.findall(dec.name)) > 0
-                        for dec in definition.decorators)
-                    if not skipping_all and not decorator_skip:
-                        error = this_check(self, definition,
-                                           definition.docstring)
-                    else:
-                        error = None
-                    errors = error if hasattr(error, '__iter__') else [error]
-                    for error in errors:
-                        if error is not None and error.code not in \
-                                definition.skipped_error_codes:
-                            partition = this_check.__doc__.partition('.\n')
-                            message, _, explanation = partition
-                            error.set_context(explanation=explanation,
-                                              definition=definition)
-                            yield error
-                            if this_check._terminal:
-                                terminate = True
-                                break
-                if terminate:
-                    break
+        yield from check_source(source, filename, ignore_decorators=ignore_decorators)
 
     @property
     def checks(self):
-        all = [this_check for this_check in vars(type(self)).values()
-               if hasattr(this_check, '_check_for')]
-        return sorted(all, key=lambda this_check: not this_check._terminal)
+        return _get_checks()
 
-    @check_for(Definition, terminal=True)
-    def check_docstring_missing(self, definition, docstring):
-        """D10{0,1,2,3}: Public definitions should have docstrings.
 
-        All modules should normally have docstrings.  [...] all functions and
-        classes exported by a module should also have docstrings. Public
-        methods (including the __init__ constructor) should also have
-        docstrings.
+def _get_checks():
+    all = [this_check for this_check in get_checkers()
+            if hasattr(this_check, '_check_for')]
+    return sorted(all, key=lambda this_check: not this_check._terminal)
 
-        Note: Public (exported) definitions are either those with names listed
-              in __all__ variable (if present), or those that do not start
-              with a single underscore.
 
-        """
-        if (not docstring and definition.is_public or
-                docstring and is_blank(ast.literal_eval(docstring))):
-            codes = {Module: violations.D100,
-                     Class: violations.D101,
-                     NestedClass: violations.D106,
-                     Method: (lambda: violations.D105() if definition.is_magic
-                              else (violations.D107() if definition.is_init
-                              else violations.D102())),
-                     Function: violations.D103,
-                     NestedFunction: violations.D103,
-                     Package: violations.D104}
-            return codes[type(definition)]()
+def check_source(source, filename, ignore_decorators=None):
+    """Checker for PEP 257 and numpy conventions.
 
-    @check_for(Definition)
-    def check_one_liners(self, definition, docstring):
-        """D200: One-liner docstrings should fit on one line with quotes.
+    D10x: Missing docstrings
+    D20x: Whitespace issues
+    D30x: Docstring formatting
+    D40x: Docstring content issues
 
-        The closing quotes are on the same line as the opening quotes.
-        This looks better for one-liners.
-
-        """
-        if docstring:
-            lines = ast.literal_eval(docstring).split('\n')
-            if len(lines) > 1:
-                non_empty_lines = sum(1 for l in lines if not is_blank(l))
-                if non_empty_lines == 1:
-                    return violations.D200(len(lines))
-
-    @check_for(Function)
-    def check_no_blank_before(self, function, docstring):  # def
-        """D20{1,2}: No blank lines allowed around function/method docstring.
-
-        There's no blank line either before or after the docstring.
-
-        """
-        if docstring:
-            before, _, after = function.source.partition(docstring)
-            blanks_before = list(map(is_blank, before.split('\n')[:-1]))
-            blanks_after = list(map(is_blank, after.split('\n')[1:]))
-            blanks_before_count = sum(takewhile(bool, reversed(blanks_before)))
-            blanks_after_count = sum(takewhile(bool, blanks_after))
-            if blanks_before_count != 0:
-                yield violations.D201(blanks_before_count)
-            if not all(blanks_after) and blanks_after_count != 0:
-                yield violations.D202(blanks_after_count)
-
-    @check_for(Class)
-    def check_blank_before_after_class(self, class_, docstring):
-        """D20{3,4}: Class docstring should have 1 blank line around them.
-
-        Insert a blank line before and after all docstrings (one-line or
-        multi-line) that document a class -- generally speaking, the class's
-        methods are separated from each other by a single blank line, and the
-        docstring needs to be offset from the first method by a blank line;
-        for symmetry, put a blank line between the class header and the
-        docstring.
-
-        """
-        # NOTE: this gives false-positive in this case
-        # class Foo:
-        #
-        #     """Docstring."""
-        #
-        #
-        # # comment here
-        # def foo(): pass
-        if docstring:
-            before, _, after = class_.source.partition(docstring)
-            blanks_before = list(map(is_blank, before.split('\n')[:-1]))
-            blanks_after = list(map(is_blank, after.split('\n')[1:]))
-            blanks_before_count = sum(takewhile(bool, reversed(blanks_before)))
-            blanks_after_count = sum(takewhile(bool, blanks_after))
-            if blanks_before_count != 0:
-                yield violations.D211(blanks_before_count)
-            if blanks_before_count != 1:
-                yield violations.D203(blanks_before_count)
-            if not all(blanks_after) and blanks_after_count != 1:
-                yield violations.D204(blanks_after_count)
-
-    @check_for(Definition)
-    def check_blank_after_summary(self, definition, docstring):
-        """D205: Put one blank line between summary line and description.
-
-        Multi-line docstrings consist of a summary line just like a one-line
-        docstring, followed by a blank line, followed by a more elaborate
-        description. The summary line may be used by automatic indexing tools;
-        it is important that it fits on one line and is separated from the
-        rest of the docstring by a blank line.
-
-        """
-        if docstring:
-            lines = ast.literal_eval(docstring).strip().split('\n')
-            if len(lines) > 1:
-                post_summary_blanks = list(map(is_blank, lines[1:]))
-                blanks_count = sum(takewhile(bool, post_summary_blanks))
-                if blanks_count != 1:
-                    return violations.D205(blanks_count)
-
-    @staticmethod
-    def _get_docstring_indent(definition, docstring):
-        """Return the indentation of the docstring's opening quotes."""
-        before_docstring, _, _ = definition.source.partition(docstring)
-        _, _, indent = before_docstring.rpartition('\n')
-        return indent
-
-    @check_for(Definition)
-    def check_indent(self, definition, docstring):
-        """D20{6,7,8}: The entire docstring should be indented same as code.
-
-        The entire docstring is indented the same as the quotes at its
-        first line.
-
-        """
-        if docstring:
-            indent = self._get_docstring_indent(definition, docstring)
-            lines = docstring.split('\n')
-            if len(lines) > 1:
-                lines = lines[1:]  # First line does not need indent.
-                indents = [leading_space(l) for l in lines if not is_blank(l)]
-                if set(' \t') == set(''.join(indents) + indent):
-                    yield violations.D206()
-                if (len(indents) > 1 and min(indents[:-1]) > indent or
-                        indents[-1] > indent):
-                    yield violations.D208()
-                if min(indents) < indent:
-                    yield violations.D207()
-
-    @check_for(Definition)
-    def check_newline_after_last_paragraph(self, definition, docstring):
-        """D209: Put multi-line docstring closing quotes on separate line.
-
-        Unless the entire docstring fits on a line, place the closing
-        quotes on a line by themselves.
-
-        """
-        if docstring:
-            lines = [l for l in ast.literal_eval(docstring).split('\n')
-                     if not is_blank(l)]
-            if len(lines) > 1:
-                if docstring.split("\n")[-1].strip() not in ['"""', "'''"]:
-                    return violations.D209()
-
-    @check_for(Definition)
-    def check_surrounding_whitespaces(self, definition, docstring):
-        """D210: No whitespaces allowed surrounding docstring text."""
-        if docstring:
-            lines = ast.literal_eval(docstring).split('\n')
-            if lines[0].startswith(' ') or \
-                    len(lines) == 1 and lines[0].endswith(' '):
-                return violations.D210()
-
-    @check_for(Definition)
-    def check_multi_line_summary_start(self, definition, docstring):
-        """D21{2,3}: Multi-line docstring summary style check.
-
-        A multi-line docstring summary should start either at the first,
-        or separately at the second line of a docstring.
-
-        """
-        if docstring:
-            start_triple = [
-                '"""', "'''",
-                'u"""', "u'''",
-                'r"""', "r'''",
-                'ur"""', "ur'''"
-            ]
-
-            lines = ast.literal_eval(docstring).split('\n')
-            if len(lines) > 1:
-                first = docstring.split("\n")[0].strip().lower()
-                if first in start_triple:
-                    return violations.D212()
+    """
+    module = parse(StringIO(source), filename)
+    for definition in module:
+        for this_check in _get_checks():
+            terminate = False
+            if isinstance(definition, this_check._check_for):
+                skipping_all = (definition.skipped_error_codes == 'all')
+                decorator_skip = ignore_decorators is not None and any(
+                    len(ignore_decorators.findall(dec.name)) > 0
+                    for dec in definition.decorators)
+                if not skipping_all and not decorator_skip:
+                    error = this_check(definition,
+                                        definition.docstring)
                 else:
-                    return violations.D213()
-
-    @check_for(Definition)
-    def check_triple_double_quotes(self, definition, docstring):
-        r'''D300: Use """triple double quotes""".
-
-        For consistency, always use """triple double quotes""" around
-        docstrings. Use r"""raw triple double quotes""" if you use any
-        backslashes in your docstrings. For Unicode docstrings, use
-        u"""Unicode triple-quoted strings""".
-
-        Note: Exception to this is made if the docstring contains
-              """ quotes in its body.
-
-        '''
-        if docstring:
-            if '"""' in ast.literal_eval(docstring):
-                # Allow ''' quotes if docstring contains """, because
-                # otherwise """ quotes could not be expressed inside
-                # docstring. Not in PEP 257.
-                regex = re(r"[uU]?[rR]?'''[^'].*")
-            else:
-                regex = re(r'[uU]?[rR]?"""[^"].*')
-
-            if not regex.match(docstring):
-                illegal_matcher = re(r"""[uU]?[rR]?("+|'+).*""")
-                illegal_quotes = illegal_matcher.match(docstring).group(1)
-                return violations.D300(illegal_quotes)
-
-    @check_for(Definition)
-    def check_backslashes(self, definition, docstring):
-        r'''D301: Use r""" if any backslashes in a docstring.
-
-        Use r"""raw triple double quotes""" if you use any backslashes
-        (\) in your docstrings.
-
-        '''
-        # Just check that docstring is raw, check_triple_double_quotes
-        # ensures the correct quotes.
-        if docstring and '\\' in docstring and not docstring.startswith(
-                ('r', 'ur')):
-            return violations.D301()
-
-    @check_for(Definition)
-    def check_unicode_docstring(self, definition, docstring):
-        r'''D302: Use u""" for docstrings with Unicode.
-
-        For Unicode docstrings, use u"""Unicode triple-quoted strings""".
-
-        '''
-        if 'unicode_literals' in definition.module.future_imports:
-            return
-
-        # Just check that docstring is unicode, check_triple_double_quotes
-        # ensures the correct quotes.
-        if docstring and sys.version_info[0] <= 2:
-            if not is_ascii(docstring) and not docstring.startswith(
-                    ('u', 'ur')):
-                return violations.D302()
-
-    @check_for(Definition)
-    def check_ends_with_period(self, definition, docstring):
-        """D400: First line should end with a period.
-
-        The [first line of a] docstring is a phrase ending in a period.
-
-        """
-        if docstring:
-            summary_line = ast.literal_eval(docstring).strip().split('\n')[0]
-            if not summary_line.endswith('.'):
-                return violations.D400(summary_line[-1])
-
-    @check_for(Function)
-    def check_imperative_mood(self, function, docstring):  # def context
-        """D401: First line should be in imperative mood: 'Do', not 'Does'.
-
-        [Docstring] prescribes the function or method's effect as a command:
-        ("Do this", "Return that"), not as a description; e.g. don't write
-        "Returns the pathname ...".
-
-        """
-        if docstring and not function.is_test:
-            stripped = ast.literal_eval(docstring).strip()
-            if stripped:
-                first_word = stripped.split()[0]
-                check_word = first_word.lower()
-
-                if check_word in IMPERATIVE_BLACKLIST:
-                    return violations.D401b(first_word)
-
-                try:
-                    correct_form = IMPERATIVE_VERBS.get(stem(check_word))
-                except UnicodeDecodeError:
-                    # This is raised when the docstring contains unicode
-                    # characters in the first word, but is not a unicode
-                    # string. In which case D302 will be reported. Ignoring.
-                    return
-
-                if correct_form and correct_form != check_word:
-                    return violations.D401(
-                        correct_form.capitalize(),
-                        first_word
-                    )
-
-    @check_for(Function)
-    def check_no_signature(self, function, docstring):  # def context
-        """D402: First line should not be function's or method's "signature".
-
-        The one-line docstring should NOT be a "signature" reiterating the
-        function/method parameters (which can be obtained by introspection).
-
-        """
-        if docstring:
-            first_line = ast.literal_eval(docstring).strip().split('\n')[0]
-            if function.name + '(' in first_line.replace(' ', ''):
-                return violations.D402()
-
-    @check_for(Function)
-    def check_capitalized(self, function, docstring):
-        """D403: First word of the first line should be properly capitalized.
-
-        The [first line of a] docstring is a phrase ending in a period.
-
-        """
-        if docstring:
-            first_word = ast.literal_eval(docstring).split()[0]
-            if first_word == first_word.upper():
-                return
-            for char in first_word:
-                if char not in string.ascii_letters and char != "'":
-                    return
-            if first_word != first_word.capitalize():
-                return violations.D403(first_word.capitalize(), first_word)
-
-    @check_for(Definition)
-    def check_starts_with_this(self, function, docstring):
-        """D404: First word of the docstring should not be `This`.
-
-        Docstrings should use short, simple language. They should not begin
-        with "This class is [..]" or "This module contains [..]".
-
-        """
-        if docstring:
-            first_word = ast.literal_eval(docstring).split()[0]
-            if first_word.lower() == 'this':
-                return violations.D404()
-
-    @staticmethod
-    def _get_leading_words(line):
-        """Return any leading set of words from `line`.
-
-        For example, if `line` is "  Hello world!!!", returns "Hello world".
-        """
-        result = re("[\w ]+").match(line.strip())
-        if result is not None:
-            return result.group()
-
-    @staticmethod
-    def _is_a_docstring_section(context):
-        """Check if the suspected context is really a section header.
-
-        Lets have a look at the following example docstring:
-            '''Title.
-
-            Some part of the docstring that specifies what the function
-            returns. <----- Not a real section name. It has a suffix and the
-                            previous line is not empty and does not end with
-                            a punctuation sign.
-
-            This is another line in the docstring. It describes stuff,
-            but we forgot to add a blank line between it and the section name.
-            Parameters  <-- A real section name. The previous line ends with
-            ----------      a period, therefore it is in a new
-                            grammatical context.
-            param : int
-            examples : list  <------- Not a section - previous line doesn't end
-                A list of examples.   with punctuation.
-            notes : list  <---------- Not a section - there's text after the
-                A list of notes.      colon.
-
-            Notes:  <--- Suspected as a context because there's a suffix to the
-            -----        section, but it's a colon so it's probably a mistake.
-            Bla.
-
-            '''
-
-        To make sure this is really a section we check these conditions:
-            * There's no suffix to the section name or it's just a colon AND
-            * The previous line is empty OR it ends with punctuation.
-
-        If one of the conditions is true, we will consider the line as
-        a section name.
-        """
-        section_name_suffix = \
-            context.line.strip().lstrip(context.section_name.strip()).strip()
-
-        section_suffix_is_only_colon = section_name_suffix == ':'
-
-        punctuation = [',', ';', '.', '-', '\\', '/', ']', '}', ')']
-        prev_line_ends_with_punctuation = \
-            any(context.previous_line.strip().endswith(x) for x in punctuation)
-
-        this_line_looks_like_a_section_name = \
-            is_blank(section_name_suffix) or section_suffix_is_only_colon
-        
-        prev_line_looks_like_end_of_paragraph = \
-            prev_line_ends_with_punctuation or is_blank(context.previous_line)
-
-        return (this_line_looks_like_a_section_name and
-                prev_line_looks_like_end_of_paragraph)
-
-    @classmethod
-    def _check_section_underline(cls, section_name, context, indentation):
-        """D4{07,08,09,12}, D215: Section underline checks.
-
-        Check for correct formatting for docstring sections. Checks that:
-            * The line that follows the section name contains
-              dashes (D40{7,8}).
-            * The amount of dashes is equal to the length of the section
-              name (D409).
-            * The section's content does not begin in the line that follows
-              the section header (D412).
-            * The indentation of the dashed line is equal to the docstring's
-              indentation (D215).
-        """
-        blank_lines_after_header = 0
-
-        for line in context.following_lines:
-            if not is_blank(line):
+                    error = None
+                errors = error if hasattr(error, '__iter__') else [error]
+                for error in errors:
+                    if error is not None and error.code not in \
+                            definition.skipped_error_codes:
+                        partition = this_check.__doc__.partition('.\n')
+                        message, _, explanation = partition
+                        error.set_context(explanation=explanation,
+                                            definition=definition)
+                        yield error
+                        if this_check._terminal:
+                            terminate = True
+                            break
+            if terminate:
                 break
-            blank_lines_after_header += 1
-        else:
-            # There are only blank lines after the header.
-            yield violations.D407(section_name)
-            return
-
-        non_empty_line = context.following_lines[blank_lines_after_header]
-        dash_line_found = ''.join(set(non_empty_line.strip())) == '-'
-
-        if not dash_line_found:
-            yield violations.D407(section_name)
-            if blank_lines_after_header > 0:
-                yield violations.D412(section_name)
-        else:
-            if blank_lines_after_header > 0:
-                yield violations.D408(section_name)
-
-            if non_empty_line.strip() != "-" * len(section_name):
-                yield violations.D409(len(section_name),
-                                      section_name,
-                                      len(non_empty_line.strip()))
-
-            if leading_space(non_empty_line) > indentation:
-                yield violations.D215(section_name)
-
-            line_after_dashes_index = blank_lines_after_header + 1
-            # If the line index after the dashes is in range (perhaps we have
-            # a header + underline followed by another section header).
-            if line_after_dashes_index < len(context.following_lines):
-                line_after_dashes = \
-                    context.following_lines[line_after_dashes_index]
-                if is_blank(line_after_dashes):
-                    rest_of_lines = \
-                        context.following_lines[line_after_dashes_index:]
-                    if not is_blank(''.join(rest_of_lines)):
-                        yield violations.D412(section_name)
-                    else:
-                        yield violations.D414(section_name)
-            else:
-                yield violations.D414(section_name)
-
-    @classmethod
-    def _check_section(cls, docstring, definition, context):
-        """D4{05,06,10,11,13}, D214: Section name checks.
-
-        Check for valid section names. Checks that:
-            * The section name is properly capitalized (D405).
-            * The section is not over-indented (D214).
-            * The section name has no superfluous suffix to it (D406).
-            * There's a blank line after the section (D410, D413).
-            * There's a blank line before the section (D411).
-
-        Also yields all the errors from `_check_section_underline`.
-        """
-        capitalized_section = context.section_name.title()
-        indentation = cls._get_docstring_indent(definition, docstring)
-
-        if (context.section_name not in cls.SECTION_NAMES and
-                capitalized_section in cls.SECTION_NAMES):
-            yield violations.D405(capitalized_section, context.section_name)
-
-        if leading_space(context.line) > indentation:
-            yield violations.D214(capitalized_section)
-
-        suffix = context.line.strip().lstrip(context.section_name)
-        if suffix:
-            yield violations.D406(capitalized_section, context.line.strip())
-
-        if (not context.following_lines or
-                not is_blank(context.following_lines[-1])):
-            if context.is_last_section:
-                yield violations.D413(capitalized_section)
-            else:
-                yield violations.D410(capitalized_section)
-
-        if not is_blank(context.previous_line):
-            yield violations.D411(capitalized_section)
-
-        for err in cls._check_section_underline(capitalized_section,
-                                                context,
-                                                indentation):
-            yield err
-
-    @check_for(Definition)
-    def check_docstring_sections(self, definition, docstring):
-        """D21{4,5}, D4{05,06,07,08,09,10}: Docstring sections checks.
-
-        Check the general format of a sectioned docstring:
-            '''This is my one-liner.
-
-            Short Summary
-            -------------
-            This is my summary.
-
-            Returns
-            -------
-            None.
-
-            '''
-
-        Section names appear in `SECTION_NAMES`.
-        """
-        if not docstring:
-            return
-
-        lines = docstring.split("\n")
-        if len(lines) < 2:
-            return
-
-        lower_section_names = [s.lower() for s in self.SECTION_NAMES]
-
-        def _suspected_as_section(_line):
-            result = self._get_leading_words(_line.lower())
-            return result in lower_section_names
-
-        # Finding our suspects.
-        suspected_section_indices = [i for i, line in enumerate(lines) if
-                                     _suspected_as_section(line)]
-
-        SectionContext = namedtuple('SectionContext', ('section_name',
-                                                       'previous_line',
-                                                       'line',
-                                                       'following_lines',
-                                                       'original_index',
-                                                       'is_last_section'))
-
-        # First - create a list of possible contexts. Note that the
-        # `following_lines` member is until the end of the docstring.
-        contexts = (SectionContext(self._get_leading_words(lines[i].strip()),
-                                   lines[i - 1],
-                                   lines[i],
-                                   lines[i + 1:],
-                                   i,
-                                   False)
-                    for i in suspected_section_indices)
-
-        # Now that we have manageable objects - rule out false positives.
-        contexts = (c for c in contexts if self._is_a_docstring_section(c))
-
-        # Now we shall trim the `following lines` field to only reach the
-        # next section name.
-        for a, b in pairwise(contexts, None):
-            end = -1 if b is None else b.original_index
-            new_ctx = SectionContext(a.section_name,
-                                     a.previous_line,
-                                     a.line,
-                                     lines[a.original_index + 1:end],
-                                     a.original_index,
-                                     b is None)
-            for err in self._check_section(docstring, definition, new_ctx):
-                yield err
 
 
 parse = Parser()
@@ -706,8 +123,7 @@ def check(filenames, select=None, ignore=None, ignore_decorators=None):
         try:
             with tk.open(filename) as file:
                 source = file.read()
-            for error in ConventionChecker().check_source(source, filename,
-                                                          ignore_decorators):
+            for error in check_source(source, filename, ignore_decorators):
                 code = getattr(error, 'code', None)
                 if code in checked_codes:
                     yield error
@@ -716,11 +132,3 @@ def check(filenames, select=None, ignore=None, ignore_decorators=None):
             yield error
         except tk.TokenError:
             yield SyntaxError('invalid syntax in file %s' % filename)
-
-
-def is_ascii(string):
-    return all(ord(char) < 128 for char in string)
-
-
-def leading_space(string):
-    return re('\s*').match(string).group()

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -1,6 +1,7 @@
 """Parsed source code checkers for docstring violations."""
 
 import tokenize as tk
+import warnings
 
 from pydocstyle import violations
 from pydocstyle.checkers import get_checkers
@@ -9,11 +10,15 @@ from pydocstyle.parser import Parser, StringIO, ParseError, AllError
 from pydocstyle.utils import log
 
 
-__all__ = ('check', )
+__all__ = ('check', 'check_source')
 
 
 class ConventionChecker:
-    """Checker for PEP 257 and numpy conventions.
+    """Deprecated: Checker for PEP 257 and numpy conventions.
+
+    Deprecated class. Use `pydocstyle.check_source` instead.
+    >>> from pydocstyle import check_source
+    >>> check_source(source, filename, ignore_decorators=None)
 
     D10x: Missing docstrings
     D20x: Whitespace issues
@@ -22,11 +27,18 @@ class ConventionChecker:
 
     """
 
+    def __init__(self):
+        warnings.warn("`ConventionChecker` is deprecated. "
+                      "Use the `pydocstyle.check_source` instead", DeprecationWarning)
+
     def check_source(self, source, filename, ignore_decorators=None):
+        warnings.warn("`ConventionChecker.check_source` is deprecated. "
+                      "Use `pydocstyle.check_source` instead", DeprecationWarning)
         yield from check_source(source, filename, ignore_decorators=ignore_decorators)
 
     @property
     def checks(self):
+        warnings.warn("`ConventionChecker.checks` is deprecated.", DeprecationWarning)
         return _get_checks()
 
 

--- a/src/pydocstyle/checkers/__init__.py
+++ b/src/pydocstyle/checkers/__init__.py
@@ -1,0 +1,6 @@
+from pydocstyle.checkers.hooks import get_checkers
+# These imports below are required for registering the
+# checkers so that `get_checkers` captures them.
+from pydocstyle.checkers.style import numpy, base, other
+
+__all__ = ('get_checkers', 'numpy', 'base', 'other')

--- a/src/pydocstyle/checkers/hooks.py
+++ b/src/pydocstyle/checkers/hooks.py
@@ -1,0 +1,13 @@
+__registered_checkers = []
+
+def check_for(kind, terminal=False):
+    def decorator(f):
+        __registered_checkers.append(f)
+        f._check_for = kind
+        f._terminal = terminal
+        return f
+    return decorator
+
+
+def get_checkers():
+    return  iter(__registered_checkers)

--- a/src/pydocstyle/checkers/style/base.py
+++ b/src/pydocstyle/checkers/style/base.py
@@ -1,0 +1,356 @@
+import ast
+import re
+import string
+import sys
+
+from itertools import takewhile
+
+from pydocstyle import violations
+from pydocstyle.checkers.hooks import check_for
+from pydocstyle.checkers.utils import (
+    get_docstring_indent,
+    get_leading_space
+)
+from pydocstyle.parser import (
+    Class,
+    Definition,
+    Function,
+    Method,
+    Module,
+    NestedClass,
+    NestedFunction,
+    Package,
+)
+from pydocstyle.utils import log, is_blank, pairwise
+from pydocstyle.wordlists import IMPERATIVE_VERBS, IMPERATIVE_BLACKLIST, stem
+
+
+TRIPLE_QUOTES_REGEX = re.compile(r"[uU]?[rR]?'''[^'].*")
+TRIPLE_DOUBLE_QUOTES_REGEX = re.compile(r'[uU]?[rR]?"""[^"].*')
+ILLEGAL_QUOTES_REGEX = re.compile(r"""[uU]?[rR]?("+|'+).*""")
+
+
+# ===========
+# D1XX Checks
+# ===========
+
+
+@check_for(Definition, terminal=True)
+def check_docstring_missing(definition, docstring):
+    """D10{0,1,2,3}: Public definitions should have docstrings.
+
+    All modules should normally have docstrings.  [...] all functions and
+    classes exported by a module should also have docstrings. Public
+    methods (including the __init__ constructor) should also have
+    docstrings.
+
+    Note: Public (exported) definitions are either those with names listed
+            in __all__ variable (if present), or those that do not start
+            with a single underscore.
+
+    """
+    if (not docstring and definition.is_public or
+            docstring and is_blank(ast.literal_eval(docstring))):
+        codes = {Module: violations.D100,
+                    Class: violations.D101,
+                    NestedClass: violations.D106,
+                    Method: (lambda: violations.D105() if definition.is_magic
+                            else (violations.D107() if definition.is_init
+                            else violations.D102())),
+                    Function: violations.D103,
+                    NestedFunction: violations.D103,
+                    Package: violations.D104}
+        return codes[type(definition)]()
+
+
+# ===========
+# D2XX Checks
+# ===========
+
+
+@check_for(Definition)
+def check_one_liners(definition, docstring):
+    """D200: One-liner docstrings should fit on one line with quotes.
+
+    The closing quotes are on the same line as the opening quotes.
+    This looks better for one-liners.
+
+    """
+    if docstring:
+        lines = ast.literal_eval(docstring).split('\n')
+        if len(lines) > 1:
+            non_empty_lines = sum(1 for l in lines if not is_blank(l))
+            if non_empty_lines == 1:
+                return violations.D200(len(lines))
+
+
+
+@check_for(Function)
+def check_no_blank_before(function, docstring):  # def
+    """D20{1,2}: No blank lines allowed around function/method docstring.
+
+    There's no blank line either before or after the docstring.
+
+    """
+    if docstring:
+        before, _, after = function.source.partition(docstring)
+        blanks_before = list(map(is_blank, before.split('\n')[:-1]))
+        blanks_after = list(map(is_blank, after.split('\n')[1:]))
+        blanks_before_count = sum(takewhile(bool, reversed(blanks_before)))
+        blanks_after_count = sum(takewhile(bool, blanks_after))
+        if blanks_before_count != 0:
+            yield violations.D201(blanks_before_count)
+        if not all(blanks_after) and blanks_after_count != 0:
+            yield violations.D202(blanks_after_count)
+
+
+@check_for(Class)
+def check_blank_before_after_class(class_, docstring):
+    """D20{3,4}: Class docstring should have 1 blank line around them.
+
+    Insert a blank line before and after all docstrings (one-line or
+    multi-line) that document a class -- generally speaking, the class's
+    methods are separated from each other by a single blank line, and the
+    docstring needs to be offset from the first method by a blank line;
+    for symmetry, put a blank line between the class header and the
+    docstring.
+
+    """
+    # NOTE: this gives false-positive in this case
+    # class Foo:
+    #
+    #     """Docstring."""
+    #
+    #
+    # # comment here
+    # def foo(): pass
+    if docstring:
+        before, _, after = class_.source.partition(docstring)
+        blanks_before = list(map(is_blank, before.split('\n')[:-1]))
+        blanks_after = list(map(is_blank, after.split('\n')[1:]))
+        blanks_before_count = sum(takewhile(bool, reversed(blanks_before)))
+        blanks_after_count = sum(takewhile(bool, blanks_after))
+        if blanks_before_count != 0:
+            yield violations.D211(blanks_before_count)
+        if blanks_before_count != 1:
+            yield violations.D203(blanks_before_count)
+        if not all(blanks_after) and blanks_after_count != 1:
+            yield violations.D204(blanks_after_count)
+
+
+@check_for(Definition)
+def check_blank_after_summary(definition, docstring):
+    """D205: Put one blank line between summary line and description.
+
+    Multi-line docstrings consist of a summary line just like a one-line
+    docstring, followed by a blank line, followed by a more elaborate
+    description. The summary line may be used by automatic indexing tools;
+    it is important that it fits on one line and is separated from the
+    rest of the docstring by a blank line.
+
+    """
+    if docstring:
+        lines = ast.literal_eval(docstring).strip().split('\n')
+        if len(lines) > 1:
+            post_summary_blanks = list(map(is_blank, lines[1:]))
+            blanks_count = sum(takewhile(bool, post_summary_blanks))
+            if blanks_count != 1:
+                return violations.D205(blanks_count)
+
+
+@check_for(Definition)
+def check_indent(definition, docstring):
+    """D20{6,7,8}: The entire docstring should be indented same as code.
+
+    The entire docstring is indented the same as the quotes at its
+    first line.
+
+    """
+    if docstring:
+        indent = get_docstring_indent(definition, docstring)
+        lines = docstring.split('\n')
+        if len(lines) > 1:
+            lines = lines[1:]  # First line does not need indent.
+            indents = [get_leading_space(l) for l in lines if not is_blank(l)]
+            if set(' \t') == set(''.join(indents) + indent):
+                yield violations.D206()
+            if (len(indents) > 1 and min(indents[:-1]) > indent or
+                    indents[-1] > indent):
+                yield violations.D208()
+            if min(indents) < indent:
+                yield violations.D207()
+
+
+@check_for(Definition)
+def check_newline_after_last_paragraph(definition, docstring):
+    """D209: Put multi-line docstring closing quotes on separate line.
+
+    Unless the entire docstring fits on a line, place the closing
+    quotes on a line by themselves.
+
+    """
+    if docstring:
+        lines = [l for l in ast.literal_eval(docstring).split('\n')
+                    if not is_blank(l)]
+        if len(lines) > 1:
+            if docstring.split("\n")[-1].strip() not in ['"""', "'''"]:
+                return violations.D209()
+
+
+@check_for(Definition)
+def check_surrounding_whitespaces(definition, docstring):
+    """D210: No whitespaces allowed surrounding docstring text."""
+    if docstring:
+        lines = ast.literal_eval(docstring).split('\n')
+        if lines[0].startswith(' ') or \
+                len(lines) == 1 and lines[0].endswith(' '):
+            return violations.D210()
+
+
+# ===========
+# D3XX Checks
+# ===========
+
+
+@check_for(Definition)
+def check_triple_double_quotes(definition, docstring):
+    r'''D300: Use """triple double quotes""".
+
+    For consistency, always use """triple double quotes""" around
+    docstrings. Use r"""raw triple double quotes""" if you use any
+    backslashes in your docstrings. For Unicode docstrings, use
+    u"""Unicode triple-quoted strings""".
+
+    Note: Exception to this is made if the docstring contains
+            """ quotes in its body.
+
+    '''
+    if docstring:
+        if '"""' in ast.literal_eval(docstring):
+            # Allow ''' quotes if docstring contains """, because
+            # otherwise """ quotes could not be expressed inside
+            # docstring. Not in PEP 257.
+            regex = TRIPLE_QUOTES_REGEX
+        else:
+            regex = TRIPLE_DOUBLE_QUOTES_REGEX
+
+        if not regex.match(docstring):
+            illegal_quotes = ILLEGAL_QUOTES_REGEX.match(docstring).group(1)
+            return violations.D300(illegal_quotes)
+
+
+
+@check_for(Definition)
+def check_backslashes(definition, docstring):
+    r'''D301: Use r""" if any backslashes in a docstring.
+
+    Use r"""raw triple double quotes""" if you use any backslashes
+    (\) in your docstrings.
+
+    '''
+    # Just check that docstring is raw, check_triple_double_quotes
+    # ensures the correct quotes.
+    if docstring and '\\' in docstring and not docstring.startswith(
+            ('r', 'ur')):
+        return violations.D301()
+
+
+@check_for(Definition)
+def check_unicode_docstring(definition, docstring):
+    r'''D302: Use u""" for docstrings with Unicode.
+
+    For Unicode docstrings, use u"""Unicode triple-quoted strings""".
+
+    '''
+    if 'unicode_literals' in definition.module.future_imports:
+        return
+
+    # Just check that docstring is unicode, check_triple_double_quotes
+    # ensures the correct quotes.
+    if docstring and sys.version_info[0] <= 2:
+        if not is_ascii(docstring) and not docstring.startswith(
+                ('u', 'ur')):
+            return violations.D302()
+
+
+# ===========
+# D4XX Checks
+# ===========
+
+
+@check_for(Definition)
+def check_ends_with_period(definition, docstring):
+    """D400: First line should end with a period.
+
+    The [first line of a] docstring is a phrase ending in a period.
+
+    """
+    if docstring:
+        summary_line = ast.literal_eval(docstring).strip().split('\n')[0]
+        if not summary_line.endswith('.'):
+            return violations.D400(summary_line[-1])
+
+
+@check_for(Function)
+def check_imperative_mood(function, docstring):  # def context
+    """D401: First line should be in imperative mood: 'Do', not 'Does'.
+
+    [Docstring] prescribes the function or method's effect as a command:
+    ("Do this", "Return that"), not as a description; e.g. don't write
+    "Returns the pathname ...".
+
+    """
+    if docstring and not function.is_test:
+        stripped = ast.literal_eval(docstring).strip()
+        if stripped:
+            first_word = stripped.split()[0]
+            check_word = first_word.lower()
+
+            if check_word in IMPERATIVE_BLACKLIST:
+                return violations.D401b(first_word)
+
+            try:
+                correct_form = IMPERATIVE_VERBS.get(stem(check_word))
+            except UnicodeDecodeError:
+                # This is raised when the docstring contains unicode
+                # characters in the first word, but is not a unicode
+                # string. In which case D302 will be reported. Ignoring.
+                return
+
+            if correct_form and correct_form != check_word:
+                return violations.D401(
+                    correct_form.capitalize(),
+                    first_word
+                )
+
+
+@check_for(Function)
+def check_no_signature(function, docstring):  # def context
+    """D402: First line should not be function's or method's "signature".
+
+    The one-line docstring should NOT be a "signature" reiterating the
+    function/method parameters (which can be obtained by introspection).
+
+    """
+    if docstring:
+        first_line = ast.literal_eval(docstring).strip().split('\n')[0]
+        if function.name + '(' in first_line.replace(' ', ''):
+            return violations.D402()
+
+
+@check_for(Function)
+def check_capitalized(function, docstring):
+    """D403: First word of the first line should be properly capitalized.
+
+    The [first line of a] docstring is a phrase ending in a period.
+
+    """
+    if docstring:
+        first_word = ast.literal_eval(docstring).split()[0]
+        if first_word == first_word.upper():
+            return
+        for char in first_word:
+            if char not in string.ascii_letters and char != "'":
+                return
+        if first_word != first_word.capitalize():
+            return violations.D403(first_word.capitalize(), first_word)

--- a/src/pydocstyle/checkers/style/numpy.py
+++ b/src/pydocstyle/checkers/style/numpy.py
@@ -1,0 +1,271 @@
+import ast
+import re
+from collections import namedtuple
+
+from pydocstyle import violations
+from pydocstyle.checkers.hooks import check_for
+from pydocstyle.checkers.utils import (
+    get_docstring_indent,
+    get_leading_space,
+    get_leading_words
+)
+from pydocstyle.parser import (
+    Definition,
+)
+from pydocstyle.utils import log, is_blank, pairwise
+
+NUMPY_SECTION_NAMES = [
+    'Short Summary',
+    'Extended Summary',
+    'Parameters',
+    'Returns',
+    'Yields',
+    'Other Parameters',
+    'Raises',
+    'See Also',
+    'Notes',
+    'References',
+    'Examples',
+    'Attributes',
+    'Methods'
+]
+
+
+@check_for(Definition)
+def check_starts_with_this(function, docstring):
+    """D404: First word of the docstring should not be `This`.
+
+    Docstrings should use short, simple language. They should not begin
+    with "This class is [..]" or "This module contains [..]".
+
+    """
+    if docstring:
+        first_word = ast.literal_eval(docstring).split()[0]
+        if first_word.lower() == 'this':
+            return violations.D404()
+
+
+@check_for(Definition)
+def check_docstring_sections(definition, docstring):
+    """D21{4,5}, D4{05,06,07,08,09,10}: Docstring sections checks.
+
+    Check the general format of a sectioned docstring:
+        '''This is my one-liner.
+
+        Short Summary
+        -------------
+        This is my summary.
+
+        Returns
+        -------
+        None.
+
+        '''
+
+    Section names appear in `NUMPY_SECTION_NAMES`.
+    """
+    if not docstring:
+        return
+
+    lines = docstring.split("\n")
+    if len(lines) < 2:
+        return
+
+    lower_section_names = set(s.lower() for s in NUMPY_SECTION_NAMES)
+
+    def _suspected_as_section(_line, valid_names):
+        result = get_leading_words(_line.lower())
+        return result in valid_names
+
+    # Finding our suspects.
+    suspected_section_indices = [i for i, line in enumerate(lines) if
+                                    _suspected_as_section(line, lower_section_names)]
+
+    SectionContext = namedtuple('SectionContext', ('section_name',
+                                                    'previous_line',
+                                                    'line',
+                                                    'following_lines',
+                                                    'original_index',
+                                                    'is_last_section'))
+
+    # First - create a list of possible contexts. Note that the
+    # `following_lines` member is until the end of the docstring.
+    contexts = (SectionContext(get_leading_words(lines[i].strip()),
+                                lines[i - 1],
+                                lines[i],
+                                lines[i + 1:],
+                                i,
+                                False)
+                for i in suspected_section_indices)
+
+    # Now that we have manageable objects - rule out false positives.
+    contexts = (c for c in contexts if _is_a_docstring_section(c))
+
+    # Now we shall trim the `following lines` field to only reach the
+    # next section name.
+    for a, b in pairwise(contexts, None):
+        end = -1 if b is None else b.original_index
+        new_ctx = SectionContext(a.section_name,
+                                    a.previous_line,
+                                    a.line,
+                                    lines[a.original_index + 1:end],
+                                    a.original_index,
+                                    b is None)
+        for err in _check_section(docstring, definition, new_ctx):
+            yield err
+
+
+def _check_section(docstring, definition, context):
+    """D4{05,06,10,11,13}, D214: Section name checks.
+
+    Check for valid section names. Checks that:
+        * The section name is properly capitalized (D405).
+        * The section is not over-indented (D214).
+        * The section name has no superfluous suffix to it (D406).
+        * There's a blank line after the section (D410, D413).
+        * There's a blank line before the section (D411).
+
+    Also yields all the errors from `_check_section_underline`.
+    """
+    capitalized_section = context.section_name.title()
+    indentation = get_docstring_indent(definition, docstring)
+
+    if (context.section_name not in NUMPY_SECTION_NAMES and
+            capitalized_section in NUMPY_SECTION_NAMES):
+        yield violations.D405(capitalized_section, context.section_name)
+
+    if get_leading_space(context.line) > indentation:
+        yield violations.D214(capitalized_section)
+
+    suffix = context.line.strip().lstrip(context.section_name)
+    if suffix:
+        yield violations.D406(capitalized_section, context.line.strip())
+
+    if (not context.following_lines or
+            not is_blank(context.following_lines[-1])):
+        if context.is_last_section:
+            yield violations.D413(capitalized_section)
+        else:
+            yield violations.D410(capitalized_section)
+
+    if not is_blank(context.previous_line):
+        yield violations.D411(capitalized_section)
+
+    for err in _check_section_underline(capitalized_section,
+                                            context,
+                                            indentation):
+        yield err
+
+
+def _is_a_docstring_section(context):
+    """Check if the suspected context is really a section header.
+
+    Lets have a look at the following example docstring:
+        '''Title.
+
+        Some part of the docstring that specifies what the function
+        returns. <----- Not a real section name. It has a suffix and the
+                        previous line is not empty and does not end with
+                        a punctuation sign.
+
+        This is another line in the docstring. It describes stuff,
+        but we forgot to add a blank line between it and the section name.
+        Parameters  <-- A real section name. The previous line ends with
+        ----------      a period, therefore it is in a new
+                        grammatical context.
+        param : int
+        examples : list  <------- Not a section - previous line doesn't end
+            A list of examples.   with punctuation.
+        notes : list  <---------- Not a section - there's text after the
+            A list of notes.      colon.
+
+        Notes:  <--- Suspected as a context because there's a suffix to the
+        -----        section, but it's a colon so it's probably a mistake.
+        Bla.
+
+        '''
+
+    To make sure this is really a section we check these conditions:
+        * There's no suffix to the section name or it's just a colon AND
+        * The previous line is empty OR it ends with punctuation.
+
+    If one of the conditions is true, we will consider the line as
+    a section name.
+    """
+    section_name_suffix = \
+        context.line.strip().lstrip(context.section_name.strip()).strip()
+
+    section_suffix_is_only_colon = section_name_suffix == ':'
+
+    punctuation = [',', ';', '.', '-', '\\', '/', ']', '}', ')']
+    prev_line_ends_with_punctuation = \
+        any(context.previous_line.strip().endswith(x) for x in punctuation)
+
+    this_line_looks_like_a_section_name = \
+        is_blank(section_name_suffix) or section_suffix_is_only_colon
+
+    prev_line_looks_like_end_of_paragraph = \
+        prev_line_ends_with_punctuation or is_blank(context.previous_line)
+
+    return (this_line_looks_like_a_section_name and
+            prev_line_looks_like_end_of_paragraph)
+
+
+def _check_section_underline(section_name, context, indentation):
+    """D4{07,08,09,12}, D215: Section underline checks.
+
+    Check for correct formatting for docstring sections. Checks that:
+        * The line that follows the section name contains
+            dashes (D40{7,8}).
+        * The amount of dashes is equal to the length of the section
+            name (D409).
+        * The section's content does not begin in the line that follows
+            the section header (D412).
+        * The indentation of the dashed line is equal to the docstring's
+            indentation (D215).
+    """
+    blank_lines_after_header = 0
+
+    for line in context.following_lines:
+        if not is_blank(line):
+            break
+        blank_lines_after_header += 1
+    else:
+        # There are only blank lines after the header.
+        yield violations.D407(section_name)
+        return
+
+    non_empty_line = context.following_lines[blank_lines_after_header]
+    dash_line_found = ''.join(set(non_empty_line.strip())) == '-'
+
+    if not dash_line_found:
+        yield violations.D407(section_name)
+        if blank_lines_after_header > 0:
+            yield violations.D412(section_name)
+    else:
+        if blank_lines_after_header > 0:
+            yield violations.D408(section_name)
+
+        if non_empty_line.strip() != "-" * len(section_name):
+            yield violations.D409(len(section_name),
+                                    section_name,
+                                    len(non_empty_line.strip()))
+
+        if get_leading_space(non_empty_line) > indentation:
+            yield violations.D215(section_name)
+
+        line_after_dashes_index = blank_lines_after_header + 1
+        # If the line index after the dashes is in range (perhaps we have
+        # a header + underline followed by another section header).
+        if line_after_dashes_index < len(context.following_lines):
+            line_after_dashes = \
+                context.following_lines[line_after_dashes_index]
+            if is_blank(line_after_dashes):
+                rest_of_lines = \
+                    context.following_lines[line_after_dashes_index:]
+                if not is_blank(''.join(rest_of_lines)):
+                    yield violations.D412(section_name)
+                else:
+                    yield violations.D414(section_name)
+        else:
+            yield violations.D414(section_name)

--- a/src/pydocstyle/checkers/style/other.py
+++ b/src/pydocstyle/checkers/style/other.py
@@ -1,0 +1,30 @@
+import ast
+
+from pydocstyle import violations
+from pydocstyle.parser import Definition
+from pydocstyle.checkers.hooks import check_for
+
+
+@check_for(Definition)
+def check_multi_line_summary_start(definition, docstring):
+    """D21{2,3}: Multi-line docstring summary style check.
+
+    A multi-line docstring summary should start either at the first,
+    or separately at the second line of a docstring.
+
+    """
+    if docstring:
+        start_triple = [
+            '"""', "'''",
+            'u"""', "u'''",
+            'r"""', "r'''",
+            'ur"""', "ur'''"
+        ]
+
+        lines = ast.literal_eval(docstring).split('\n')
+        if len(lines) > 1:
+            first = docstring.split("\n")[0].strip().lower()
+            if first in start_triple:
+                return violations.D212()
+            else:
+                return violations.D213()

--- a/src/pydocstyle/checkers/utils.py
+++ b/src/pydocstyle/checkers/utils.py
@@ -1,0 +1,24 @@
+import re
+
+_LEADING_SPACE_REGEX = re.compile("\s*")
+_LEADING_WORDS_REGEX = re.compile("[\w ]+")
+
+def get_leading_space(string):
+    return _LEADING_SPACE_REGEX.match(string).group()
+
+
+def get_docstring_indent(definition, docstring):
+    """Return the indentation of the docstring's opening quotes."""
+    before_docstring, _, _ = definition.source.partition(docstring)
+    _, _, indent = before_docstring.rpartition('\n')
+    return indent
+
+
+def get_leading_words(line):
+    """Return any leading set of words from `line`.
+
+    For example, if `line` is "  Hello world!!!", returns "Hello world".
+    """
+    result = _LEADING_WORDS_REGEX.match(line.strip())
+    if result:
+        return result.group()

--- a/src/pydocstyle/cli.py
+++ b/src/pydocstyle/cli.py
@@ -2,10 +2,10 @@
 import logging
 import sys
 
-from .utils import log
-from .violations import Error
-from .config import ConfigurationParser, IllegalConfiguration
-from .checker import check
+from pydocstyle.utils import log
+from pydocstyle.violations import Error
+from pydocstyle.config import ConfigurationParser, IllegalConfiguration
+from pydocstyle.checker import check
 
 
 __all__ = ('main', )

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -7,8 +7,8 @@ from collections import namedtuple
 from re import compile as re
 from configparser import RawConfigParser
 
-from .utils import __version__, log
-from .violations import ErrorRegistry, conventions
+from pydocstyle.utils import __version__, log
+from pydocstyle.violations import ErrorRegistry, conventions
 
 try:
     from collections.abc import Set
@@ -36,7 +36,7 @@ class ConfigurationParser:
     ------------------
     Responsible for deciding things that are related to the user interface and
     configuration discovery, e.g. verbosity, debug options, etc.
-    All run configurations default to `False` or `None` and are decided only 
+    All run configurations default to `False` or `None` and are decided only
     by CLI.
 
     Check Configurations:
@@ -175,14 +175,14 @@ class ConfigurationParser:
 
     def _get_config_by_discovery(self, node):
         """Get a configuration for checking `node` by config discovery.
-        
+
         Config discovery happens when no explicit config file is specified. The
         file system is searched for config files starting from the directory
         containing the file being checked, and up until the root directory of
         the project.
-        
+
         See `_get_config` for further details.
-        
+
         """
         path = self._get_node_dir(node)
 

--- a/src/pydocstyle/parser.py
+++ b/src/pydocstyle/parser.py
@@ -6,7 +6,7 @@ from itertools import chain, dropwhile
 from re import compile as re
 from io import StringIO
 
-from .utils import log
+from pydocstyle.utils import log
 
 __all__ = ('Parser', 'Definition', 'Module', 'Package', 'Function',
            'NestedFunction', 'Method', 'Class', 'NestedClass', 'AllError',

--- a/src/pydocstyle/violations.py
+++ b/src/pydocstyle/violations.py
@@ -5,8 +5,8 @@ from functools import partial
 from collections import namedtuple
 from typing import Iterable, Optional, List, Callable, Any
 
-from .utils import is_blank
-from .parser import Definition
+from pydocstyle.utils import is_blank
+from pydocstyle.parser import Definition
 
 
 __all__ = ('Error', 'ErrorRegistry', 'conventions')


### PR DESCRIPTION
Does the following for the checkers -
 * Improves re compile. Currently we were doing a re compile inside
function calls. Moves this out so that this compile only happens once.
 * Improve checker code quality -
   * Current checker is stateless. It was still written as a class which
	added additional complexity with addition of passing of `self`
	`cls` and using staticmethod decorators.
   * Move the checker hook out of the class.
   * Slice up the checks into base, other and numpy style checks.
 * Use `find_packages` for aut-discovery of packages.
 * Switch to absolute imports.