### PR TITLE
D301 exceptions

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -20,6 +20,10 @@ Bug Fixes
 
 * Remove D413 from the pep257 convention (#404).
 * Replace `semicolon` with `colon` in D416 messages. (#409)
+* D301 (Use r""" if any backslashes in a docstring) does not trigger on
+  backslashes for line continuation or unicode literals ``\u...`` and
+  ``\N...`` anymore. These are considered intended elements of the docstring
+  and thus should not be escaped by using a raw docstring (#365).
 
 4.0.1 - August 14th, 2019
 -------------------------
@@ -34,6 +38,7 @@ Bug Fixes
   the violation code table (#396).
 * Fixed IndentationError when parsing function arguments (#392).
 
+  
 4.0.0 - July 6th, 2019
 ----------------------
 

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -365,11 +365,16 @@ class ConventionChecker:
         Use r"""raw triple double quotes""" if you use any backslashes
         (\) in your docstrings.
 
+        Exceptions are backslashes for line-continuation and unicode escape
+        sequences \N... and \u... These are considered intended unescaped
+        content in docstrings.
         '''
         # Just check that docstring is raw, check_triple_double_quotes
         # ensures the correct quotes.
-        if docstring and '\\' in docstring and not docstring.startswith(
-                ('r', 'ur')):
+
+        if (docstring
+                and re(r'\\[^\nuN]').search(docstring)
+                and not docstring.startswith(('r', 'ur'))):
             return violations.D301()
 
     @check_for(Definition)

--- a/src/tests/test_cases/test.py
+++ b/src/tests/test_cases/test.py
@@ -270,6 +270,26 @@ def double_quotes_backslash_uppercase():
     R"""Sum\\mary."""
 
 
+@expect('D213: Multi-line docstring summary should start at the second line')
+def exceptions_of_D301():
+    """Exclude some backslashes from D301.
+
+    In particular, line continuations \
+    and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+    They are considered to be intentionally unescaped.
+    """
+
+
+if sys.version_info[0] <= 2:
+    @expect('D302: Use u""" for Unicode docstrings')
+    def unicode_unmarked():
+        """Юникод."""
+
+    @expect('D302: Use u""" for Unicode docstrings')
+    def first_word_has_unicode_byte():
+        """あy."""
+
+
 @expect("D400: First line should end with a period (not 'y')")
 @expect("D415: First line should end with a period, question mark, "
         "or exclamation point (not 'y')")


### PR DESCRIPTION
This adds a few exceptions to `D301: Use r""" if any backslashes in a docstring.`

Some backslashes are usually intended string formatting in docstrings and should not be escaped (directly or indirectly via a raw string). These include:

- Line continuations (c.f. #364).
- Unicode literals `\u...` and `\N...`.

Closes #364.

---

Thanks for submitting a PR!

Please make sure to check for the following items:
- [x] Add unit tests and integration tests where applicable.  
      If you've added an error code or changed an error code behavior,
      you should probably add or change a test case file under `tests/test_cases/` and add 
      it to the list under `tests/test_definitions.py`.  
      If you've added or changed a command line option,
      you should probably add or change a test in `tests/test_integration.py`.
- [x] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
   
Please don't get discouraged as it may take a while to get a review.
