### PR TITLE
Fix failing tests due to modifications to imperatives

### DIFF
--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -440,16 +440,16 @@ class ConventionChecker:
                     return violations.D401b(first_word)
 
                 try:
-                    correct_form = IMPERATIVE_VERBS.get(stem(check_word))
+                    correct_forms = IMPERATIVE_VERBS.get(stem(check_word))
                 except UnicodeDecodeError:
                     # This is raised when the docstring contains unicode
                     # characters in the first word, but is not a unicode
                     # string. In which case D302 will be reported. Ignoring.
                     return
 
-                if correct_form and correct_form != check_word:
+                if correct_forms and check_word not in correct_forms:
                     return violations.D401(
-                        correct_form.capitalize(),
+                        correct_forms[0].capitalize(),
                         first_word
                     )
 

--- a/src/pydocstyle/wordlists.py
+++ b/src/pydocstyle/wordlists.py
@@ -7,7 +7,8 @@ therefore we load them at import time, rather than on-demand.
 import re
 import pkgutil
 import snowballstemmer
-from typing import Iterator
+from collections import defaultdict
+from typing import Iterator, List, Dict
 
 
 #: Regular expression for stripping comments from the wordlists
@@ -36,7 +37,9 @@ def load_wordlist(name: str) -> Iterator[str]:
 
 
 #: A dict mapping stemmed verbs to the imperative form
-IMPERATIVE_VERBS = {stem(v): v for v in load_wordlist('imperatives.txt')}
+IMPERATIVE_VERBS = defaultdict(list)  # type: Dict[str, List[str]]
+for verb in load_wordlist('imperatives.txt'):
+    IMPERATIVE_VERBS[stem(verb)].append(verb)
 
 #: Words that are forbidden to appear as the first word in a docstring
 IMPERATIVE_BLACKLIST = set(load_wordlist('imperatives_blacklist.txt'))


### PR DESCRIPTION
With the recent addition of "initiate" to the list of imperatives,
both "initialize" and "initiate" stem to the same verb - "initi"
which causes an error since we use Initialize in our docs and due
to the way the imperative suggestion logic is implemented.

Since initiate occurs later in the file - when constructing a
dictionary - it trumps initialize and replaces it.

This patch fixes it by changing the dictionary to a list of verbs
instead of a single stem-verb map.

Thanks for submitting a PR!

Please make sure to check for the following items:
- [X] Add unit tests and integration tests where applicable.  
      If you've added an error code or changed an error code behavior,
      you should probably add or change a test case file under `tests/test_cases/` and add 
      it to the list under `tests/test_definitions.py`.  
      If you've added or changed a command line option,
      you should probably add or change a test in `tests/test_integration.py`.
- [ ] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
   
Please don't get discouraged as it may take a while to get a review.
