### PR TITLE
Add google convention to documentation.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,7 +9,7 @@ Current Development Version
 
 Bug Fixes
 
-* Updated usage documentation to include google convention.
+* Updated usage documentation to include google convention (#386).
 
 
 4.0.0 - July 6th, 2019

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,14 @@ Release Notes
 **pydocstyle** version numbers follow the
 `Semantic Versioning <http://semver.org/>`_ specification.
 
+Current Development Version
+---------------------------
+
+Bug Fixes
+
+* Updated usage documentation to include google convention.
+
+
 4.0.0 - July 6th, 2019
 ---------------------------
 

--- a/docs/snippets/cli.rst
+++ b/docs/snippets/cli.rst
@@ -54,7 +54,7 @@ Usage
         --convention=<name>
                             choose the basic list of checked errors by specifying
                             an existing convention. Possible conventions: pep257,
-                            numpy.
+                            numpy, google.
         --add-select=<codes>
                             add extra error codes to check to the basic list of
                             errors previously set by --select, --ignore or


### PR DESCRIPTION
Updates usage documentation to reflect new google convention as pointed out in #376.

*NOTE: Test breakage is not related to this PR.*