### PR TITLE
Fix IndentationError while parsing function

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,6 +13,7 @@ Bug Fixes
   e.g., init and initialize / initiate (#382).
 * Fix parser hanging when there's a comment directly after ``__all__``
   (#391, #366).
+* Fixed IndentationError when parsing function arguments (#392).
 
 4.0.0 - July 6th, 2019
 ---------------------------

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -3,6 +3,7 @@
 import ast
 import string
 import sys
+import textwrap
 import tokenize as tk
 from itertools import takewhile, chain
 from re import compile as re
@@ -917,7 +918,7 @@ def get_leading_words(line):
 
 def get_function_args(function_string):
     """Return the function arguments given the source-code string."""
-    function_arg_node = ast.parse(function_string).body[0].args
+    function_arg_node = ast.parse(textwrap.dedent(function_string)).body[0].args
     arg_nodes = function_arg_node.args
     kwonly_arg_nodes = function_arg_node.kwonlyargs
     return set(arg_node.arg for arg_node in chain(arg_nodes, kwonly_arg_nodes))

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -1110,7 +1110,7 @@ def test_syntax_error_multiple_files(env):
 
 
 def test_indented_function(env):
-    """Test that nested functions do not cause IndentationError """
+    """Test that nested functions do not cause IndentationError."""
     env.write_config(ignore='D')
     with env.open("test.py", 'wt') as fobj:
         fobj.write(textwrap.dedent('''\

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -1107,3 +1107,22 @@ def test_syntax_error_multiple_files(env):
     assert code == 1
     assert 'first.py: Cannot parse file' in err
     assert 'second.py: Cannot parse file' in err
+
+
+def test_indented_function(env):
+    """Test that nested functions do not cause IndentationError """
+    env.write_config(ignore='D')
+    with env.open("test.py", 'wt') as fobj:
+        fobj.write(textwrap.dedent('''\
+            def foo():
+                def bar(a):
+                    """A docstring
+
+                    Args:
+                        a : An argument.
+                    """
+                    pass
+        '''))
+    out, err, code = env.invoke(args="-v")
+    assert code == 0
+    assert "IndentationError: unexpected indent" not in err


### PR DESCRIPTION
The `checker.get_function_args` function will fail with an IndentationError if it gets a `function_string` that is indented. This fixes that. :)

Thanks for submitting a PR!

Please make sure to check for the following items:
- [x] Add unit tests and integration tests where applicable.  
      If you've added an error code or changed an error code behavior,
      you should probably add or change a test case file under `tests/test_cases/` and add 
      it to the list under `tests/test_definitions.py`.  
      If you've added or changed a command line option,
      you should probably add or change a test in `tests/test_integration.py`.
- [x] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
   
Please don't get discouraged as it may take a while to get a review.