### PR TITLE
feat(checker): update D202 for inner functions

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,6 +13,8 @@ Bug Fixes
   e.g., init and initialize / initiate (#382).
 * Fix parser hanging when there's a comment directly after ``__all__``
   (#391, #366).
+* D202: Allow a blank line after function docstring when the function begins with
+  an inner function (#361).
 
 4.0.0 - July 6th, 2019
 ---------------------------

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -199,7 +199,9 @@ class ConventionChecker:
             if blanks_before_count != 0:
                 yield violations.D201(blanks_before_count)
             if not all(blanks_after) and blanks_after_count != 0:
-                yield violations.D202(blanks_after_count)
+                def_follows = after.split("\n")[2].lstrip().startswith('def')
+                if not (blanks_after_count == 1 and def_follows):
+                    yield violations.D202(blanks_after_count)
 
     @check_for(Class)
     def check_blank_before_after_class(self, class_, docstring):

--- a/src/tests/test_cases/functions.py
+++ b/src/tests/test_cases/functions.py
@@ -1,0 +1,29 @@
+""" Function docstrings """
+
+from .expected import Expectation
+
+expectation = Expectation()
+expect = expectation.expect
+
+
+@expect("D201: No blank lines allowed before docstring")
+def func_with_space_before():
+
+    """Func with space before."""
+    pass
+
+
+@expect("D202: No blank lines allowed after docstring")
+def func_with_space_after():
+    """Func with space after."""
+
+    pass
+
+
+def func_with_inner_func_after():
+    """Func with inner after."""
+
+    def inner():
+        pass
+
+    pass

--- a/src/tests/test_definitions.py
+++ b/src/tests/test_definitions.py
@@ -19,6 +19,7 @@ from pydocstyle.checker import check
     'superfluous_quotes',
     'noqa',
     'sections',
+    'functions',
 ])
 def test_complex_file(test_case):
     """Run domain-specific tests from test.py file."""


### PR DESCRIPTION
Changes D202: No blank lines allowed after function docstring to allow
space below function docstrings with inner functions:

i.e. allows

```python

def outer():
    """Valid docstring."""

    def inner():
        pass

    return pass
```

See comment from @cdeil in #361.

Thanks for submitting a PR!

Please make sure to check for the following items:
- [x] Add unit tests and integration tests where applicable.  
      If you've added an error code or changed an error code behavior,
      you should probably add or change a test case file under `tests/test_cases/` and add 
      it to the list under `tests/test_definitions.py`.  
      If you've added or changed a command line option,
      you should probably add or change a test in `tests/test_integration.py`.
- [x] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
   
Please don't get discouraged as it may take a while to get a review.
