### PR TITLE
Add an 'all' convention which enables all codes at once

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -7,6 +7,10 @@ Release Notes
 Current Development Version
 ---------------------------
 
+New Features
+
+* Add ``all`` convention to expose all error codes (#398).
+
 Bug Fixes
 
 * D401: Fixed a false positive where one stem had multiple imperative forms,

--- a/src/pydocstyle/violations.py
+++ b/src/pydocstyle/violations.py
@@ -263,6 +263,7 @@ all_errors = set(ErrorRegistry.get_error_codes())
 
 
 conventions = AttrDict({
+    'all': all_errors,
     'pep257': all_errors - {'D203', 'D212', 'D213', 'D214', 'D215', 'D404',
                             'D405', 'D406', 'D407', 'D408', 'D409', 'D410',
                             'D411', 'D415', 'D416', 'D417'},


### PR DESCRIPTION
Resolves #397 

This will make it easier to expose all codes via `flake8-docstrings`

Thanks for submitting a PR!

Please make sure to check for the following items:
- [x] Add unit tests and integration tests where applicable.  
      If you've added an error code or changed an error code behavior,
      you should probably add or change a test case file under `tests/test_cases/` and add 
      it to the list under `tests/test_definitions.py`.  
      If you've added or changed a command line option,
      you should probably add or change a test in `tests/test_integration.py`.
- [x] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
   
Please don't get discouraged as it may take a while to get a review.
