### PR TITLE
[DOCONLY] Fix misnamed D416 reference: `s/semicolon/colon/g`

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -19,6 +19,7 @@ New Features
 Bug Fixes
 
 * Remove D413 from the pep257 convention (#404).
+* Replace `semicolon` with `colon` in D416 messages. (#409)
 
 4.0.1 - August 14th, 2019
 -------------------------

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -706,7 +706,7 @@ class ConventionChecker:
             * The section does not contain any blank line between its name
               and content (D412).
             * The section is not empty (D414).
-            * The section name has semicolon as a suffix (D416).
+            * The section name has colon as a suffix (D416).
 
         Additionally, also yield all violations from `_check_common_section`
         which are style-agnostic section checks.

--- a/src/pydocstyle/violations.py
+++ b/src/pydocstyle/violations.py
@@ -250,7 +250,7 @@ D413 = D4xx.create_error('D413', 'Missing blank line after last section',
 D414 = D4xx.create_error('D414', 'Section has no content', '{0!r}')
 D415 = D4xx.create_error('D415', 'First line should end with a period, question '
                                  'mark, or exclamation point', 'not {0!r}')
-D416 = D4xx.create_error('D416', 'Section name should end with a semicolon',
+D416 = D4xx.create_error('D416', 'Section name should end with a colon',
                          '{0!r}, not {1!r}')
 D417 = D4xx.create_error('D417', 'Missing arguments in the docstring',
                          'argument(s) {0!r} missing in {1!r} docstring')

--- a/src/tests/test_cases/sections.py
+++ b/src/tests/test_cases/sections.py
@@ -263,7 +263,7 @@ def valid_google_style_section():  # noqa: D406, D407
 
 
 @expect(_D213)
-@expect("D416: Section name should end with a semicolon "
+@expect("D416: Section name should end with a colon "
         "('Args:', not 'Args')")
 def missing_colon_google_style_section():  # noqa: D406, D407
     """Toggle the gizmo.


### PR DESCRIPTION
Hi! I got rather confused reading the docs about references to section names ending in _semicolons_. What's meant, and what D416 is actually checking for, is sections ending in _colons_. This PR just fixes those references. I don't _think_ this needs new tests, since it changes only the message, not the code or behaviour, but of course let me know if that's not correct :)

Please make sure to check for the following items:
- [ ] Add unit tests and integration tests where applicable. 
      If you've added an error code or changed an error code behavior,
      you should probably add or change a test case file under `tests/test_cases/` and add 
      it to the list under `tests/test_definitions.py`.  
      If you've added or changed a command line option,
      you should probably add or change a test in `tests/test_integration.py`.
- [ ] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
   
Please don't get discouraged as it may take a while to get a review.
