### PR TITLE
Fix decorator parsing

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -24,6 +24,7 @@ Bug Fixes
   backslashes for line continuation or unicode literals ``\u...`` and
   ``\N...`` anymore. These are considered intended elements of the docstring
   and thus should not be escaped by using a raw docstring (#365).
+* Fix decorator parsing (#411).
 
 4.0.1 - August 14th, 2019
 -------------------------
@@ -38,7 +39,7 @@ Bug Fixes
   the violation code table (#396).
 * Fixed IndentationError when parsing function arguments (#392).
 
-  
+
 4.0.0 - July 6th, 2019
 ----------------------
 

--- a/src/pydocstyle/parser.py
+++ b/src/pydocstyle/parser.py
@@ -267,7 +267,12 @@ class TokenStream:
         current = self._next_from_generator()
         self.current = None if current is None else Token(*current)
         self.line = self.current.start[0] if self.current else self.line
-        self.got_logical_newline = (previous.kind in self.LOGICAL_NEWLINES)
+        is_logical_blank = previous.kind in (tk.NL, tk.COMMENT)
+        self.got_logical_newline = (
+            previous.kind in self.LOGICAL_NEWLINES
+            # Retain logical_newline status if last line was logically blank
+            or (self.got_logical_newline and is_logical_blank)
+        )
         return previous
 
     def _next_from_generator(self):


### PR DESCRIPTION
Fixes #410

The bug existed because we were not accounting for cases which should
be treated as a logical new line.

Thanks for submitting a PR!

Please make sure to check for the following items:
- [X] Add unit tests and integration tests where applicable.  
      If you've added an error code or changed an error code behavior,
      you should probably add or change a test case file under `tests/test_cases/` and add 
      it to the list under `tests/test_definitions.py`.  
      If you've added or changed a command line option,
      you should probably add or change a test in `tests/test_integration.py`.
- [x] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
   
Please don't get discouraged as it may take a while to get a review.
