### PR TITLE
Support py38

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,8 +6,6 @@ environment:
     - TOXENV: "py36-install"
     - TOXENV: "py37-tests"
     - TOXENV: "py37-install"
-    - TOXENV: "py38-tests"
-    - TOXENV: "py38-install"
     - TOXENV: "py36-docs"
 
 install:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,11 +1,13 @@
 environment:
   matrix:
     - TOXENV: "py35-tests"
-    - TOXENV: "py36-tests"
-    - TOXENV: "py37-tests"
     - TOXENV: "py35-install"
+    - TOXENV: "py36-tests"
     - TOXENV: "py36-install"
+    - TOXENV: "py37-tests"
     - TOXENV: "py37-install"
+    - TOXENV: "py38-tests"
+    - TOXENV: "py38-install"
     - TOXENV: "py36-docs"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,19 @@ matrix:
   include:
     - python: 3.5
       env: TOXENV=py35-tests
-    - python: 3.6
-      env: TOXENV=py36-tests
-    - python: 3.7
-      dist: xenial
-      sudo: required
-      env: TOXENV=py37-tests
     - python: 3.5
       env: TOXENV=py35-install
     - python: 3.6
+      env: TOXENV=py36-tests
+    - python: 3.6
       env: TOXENV=py36-install
     - python: 3.7
-      dist: xenial
-      sudo: required
+      env: TOXENV=py37-tests
+    - python: 3.7
       env: TOXENV=py37-install
+    - python: 3.8
+      env: TOXENV=py38-tests
+    - python: 3.8
+      env: TOXENV=py38-install
     - python: 3.6
       env: TOXENV=docs

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -15,6 +15,7 @@ New Features
 
 * Extend support for detecting missing arguments in Google style
   docstrings to method calls (#384).
+* Added support for Python 3.8 (#423).
 
 Bug Fixes
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Operating System :: OS Independent',
         'License :: OSI Approved :: MIT License',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = {py35,py36,py37}-{tests,install},py36-docs
+envlist = {py35,py36,py37,py38}-{tests,install},py36-docs
 
 [testenv]
 download = true
@@ -35,6 +35,10 @@ skip_install = {[testenv:py37-install]skip_install}
 commands = {[testenv:py37-install]commands}
 
 [testenv:py36-install]
+skip_install = {[testenv:py37-install]skip_install}
+commands = {[testenv:py37-install]commands}
+
+[testenv:py38-install]
 skip_install = {[testenv:py37-install]skip_install}
 commands = {[testenv:py37-install]commands}
 


### PR DESCRIPTION
* Added support for Python 3.8. This will only be tested in Travis, since AppVeyor don't support it yet.
* Added to release notes and setup.py.
* Nit: Changed the order of the build matrix so each version would be together, not grouped by test/install.