### PR TITLE
Fix section mix bug

### DIFF
--- a/docs/error_codes.rst
+++ b/docs/error_codes.rst
@@ -10,7 +10,7 @@ Default conventions
 -------------------
 
 Not all error codes are checked for by default.  There are three
-conventions that may be used by pydocstyle: pep257, numpy and google.
+conventions that may be used by pydocstyle: ``pep257``, ``numpy`` and ``google``.
 
 The pep257 convention, which is enabled by default in pydocstyle,
 checks for all of the above errors except for D203, D212, D213, D214,
@@ -27,6 +27,17 @@ These conventions may be specified using `--convention=<name>` when
 running pydocstyle from the command line or by specifying the
 convention in a configuration file.  See the :ref:`cli_usage` section
 for more details.
+
+.. note::
+
+  It makes no sense to check the same docstring for both ``numpy`` and ``google``
+  conventions. Therefore, if we successfully detect that a docstring is in the
+  ``numpy`` style, we don't check it for ``google``.
+
+  The reason ``numpy`` style takes precedence over ``google`` is that the
+  heuristics of detecting it are better, and we don't want to enforce users to
+  provide external hints to `pydocstyle` in order to let it know which style
+  docstrings are written in.
 
 Publicity
 ---------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -28,6 +28,8 @@ Bug Fixes
   ``\N...`` anymore. These are considered intended elements of the docstring
   and thus should not be escaped by using a raw docstring (#365).
 * Fix decorator parsing (#411).
+* Google-style sections no longer cause false errors when used with
+  Numpy-style sections (#388, #424).
 
 4.0.1 - August 14th, 2019
 -------------------------

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -120,7 +120,6 @@ class ConventionChecker:
                     else:
                         error = None
                     errors = error if hasattr(error, '__iter__') else [error]
-
                     for error in errors:
                         if error is not None and error.code not in \
                                 definition.skipped_error_codes:

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -463,7 +463,7 @@ class ConfigurationParser(object):
                 codes_to_add = {code for code in codes
                                 if code.startswith(part)}
                 if not codes_to_add:
-                    log.warn('Error code passed is not a prefix of any known '
+                    log.warning('Error code passed is not a prefix of any known '
                              'errors: %s', part)
                 expanded_codes.update(codes_to_add)
         except TypeError as e:

--- a/src/tests/test_cases/sections.py
+++ b/src/tests/test_cases/sections.py
@@ -414,3 +414,14 @@ class TestNumpy:  # noqa: D203
             Yet another parameter.
 
         """
+
+    @staticmethod
+    def test_mixing_numpy_and_google(danger):  # noqa: D213
+        """Repro for #388.
+
+        Parameters
+        ----------
+        danger
+            Zoneeeeee!
+
+        """


### PR DESCRIPTION
This solves #388 
The problem was that the same docstring could be recognized as both google and numpy.
I changed it so numpy takes precedence since it's easier to detect.