### PR TITLE
Strip whitespace in _fix_set_options

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -19,6 +19,7 @@ New Features
   docstrings (#407).
 * Added support for Python 3.8 (#423).
 * Allow skipping errors on module level docstring via #noqa (#427).
+* Whitespace is ignored with set options split across multiple lines (#221).
 
 Bug Fixes
 

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -515,12 +515,14 @@ class ConfigurationParser:
         def _get_set(value_str):
             """Split `value_str` by the delimiter `,` and return a set.
 
-            Removes any occurrences of '' in the set.
-            Also expand error code prefixes, to avoid doing this for every
+            Removes empty values ('') and strips whitespace.
+            Also expands error code prefixes, to avoid doing this for every
             file.
 
             """
-            return cls._expand_error_codes(set(value_str.split(',')) - {''})
+            return cls._expand_error_codes(
+                set([x.strip() for x in value_str.split(",")]) - {""}
+            )
 
         for opt in optional_set_options:
             value = getattr(options, opt)

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -446,6 +446,16 @@ def test_wildcard_add_ignore_cli(env):
     assert 'D300' not in out
 
 
+def test_ignores_whitespace_in_fixed_option_set(env):
+    with env.open('example.py', 'wt') as example:
+        example.write("class Foo(object):\n    'Doc string'")
+    env.write_config(ignore="D100,\n  # comment\n  D300")
+    out, err, code = env.invoke()
+    assert code == 1
+    assert 'D300' not in out
+    assert err == ''
+
+
 def test_bad_wildcard_add_ignore_cli(env):
     """Test adding a non-existent error codes with --add-ignore."""
     with env.open('example.py', 'wt') as example:


### PR DESCRIPTION
This allows to specify e.g. "ignore" on multiple lines, without adding
additional commas:

    [pydocstyle]
    ignore = D100,D101,D102,D103,
      # "1 blank line required before class docstring"
      # Disabled by default, conflicts with D211.
      D203,
      # "Multi-line docstring summary should start at the second line" (vs. D212).
      D213,

Continuation of https://github.com/PyCQA/pydocstyle/pull/221.