### PR TITLE
Fix the AttributeError bug when parsing parameter lists in a class docstring

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,14 @@ Release Notes
 **pydocstyle** version numbers follow the
 `Semantic Versioning <http://semver.org/>`_ specification.
 
+5.0.1 - December 9th, 2019
+--------------------------
+
+Bug Fixes
+
+* Fixed an issue where AttributeError was raised when parsing the parameter
+  section of a class docstring (#434, #436).
+
 5.0.0 - December 9th, 2019
 --------------------------
 

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -758,15 +758,16 @@ class ConventionChecker:
         D417 with a list of missing arguments.
 
         """
-        function_args = get_function_args(definition.source)
-        # If the method isn't static, then we skip the first
-        # positional argument as it is `cls` or `self`
-        if definition.kind == 'method' and not definition.is_static:
-            function_args = function_args[1:]
-        missing_args = set(function_args) - docstring_args
-        if missing_args:
-            yield violations.D417(", ".join(sorted(missing_args)),
-                                  definition.name)
+        if isinstance(definition, Function):
+            function_args = get_function_args(definition.source)
+            # If the method isn't static, then we skip the first
+            # positional argument as it is `cls` or `self`
+            if definition.kind == 'method' and not definition.is_static:
+                function_args = function_args[1:]
+            missing_args = set(function_args) - docstring_args
+            if missing_args:
+                yield violations.D417(", ".join(sorted(missing_args)),
+                                      definition.name)
 
 
     @classmethod

--- a/src/tests/test_cases/test.py
+++ b/src/tests/test_cases/test.py
@@ -435,5 +435,20 @@ def bad_google_string():  # noqa: D400
     """Test a valid something"""
 
 
+# This is reproducing a bug where AttributeError is raised when parsing class
+# parameters as functions for Google / Numpy conventions.
+class Blah:  # noqa: D203,D213
+    """A Blah.
+
+    Parameters
+    ----------
+    x : int
+
+    """
+
+    def __init__(self, x):
+        pass
+
+
 expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
        'D100: Missing docstring in public module')


### PR DESCRIPTION
Reported in #434, #435.

- [x] Add unit tests.
- [x] Add a line to the release notes.

