### PR TITLE
fix invalid escape sequence

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,14 @@ Release Notes
 **pydocstyle** version numbers follow the
 `Semantic Versioning <http://semver.org/>`_ specification.
 
+Current Development Version
+---------------------------
+
+Bug Fixes
+
+* Fix ``DeprecationWarning`` / ``SyntaxError`` "invalid escape sequence" with
+  Python 3.6+ (#445).
+
 5.0.1 - December 9th, 2019
 --------------------------
 

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -64,8 +64,8 @@ class ConfigurationParser:
                            'ignore-decorators')
     BASE_ERROR_SELECTION_OPTIONS = ('ignore', 'select', 'convention')
 
-    DEFAULT_MATCH_RE = '(?!test_).*\.py'
-    DEFAULT_MATCH_DIR_RE = '[^\.].*'
+    DEFAULT_MATCH_RE = r'(?!test_).*\.py'
+    DEFAULT_MATCH_DIR_RE = r'[^\.].*'
     DEFAULT_IGNORE_DECORATORS_RE = ''
     DEFAULT_CONVENTION = conventions.pep257
 


### PR DESCRIPTION
With Python 3.6+ the `\.` in the string literals results in a `DeprecationWarning` or `SyntaxError` (in later Python versions or when using `-W error`).