### PR TITLE
Fix bug with google style arg regex

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -15,6 +15,8 @@ Bug Fixes
 
 * Update convention support documentation (#386, #393)
 * Detect inner asynchronous functions for D202 (#467)
+* Fix a bug in parsing Google-style argument description.
+  The bug caused some argument names to go unreported in D417 (#448).
 
 5.0.2 - January 8th, 2020
 ---------------------------

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -96,9 +96,9 @@ class ConventionChecker:
         r"(\w+)"        # Followed by 1 or more unicode chars, numbers or underscores
                         # The above is captured as the first group as this is the paramater name.
         r"\s*"          # Followed by 0 or more whitespace characters
-        r"\(?(.*?)\)?"  # Matches patterns contained within round brackets.
-                        # The `(.*?)` is the second capturing group which matches any sequence of
-                        # characters in a non-greedy way (denoted by the `*?`)
+        r"(\(.*?\))?"   # Matches patterns contained within round brackets.
+                        # The `.*?`matches any sequence of characters in a non-greedy
+                        # way (denoted by the `*?`)
         r"\s*"          # Followed by 0 or more whitespace chars
         r":"            # Followed by a colon
         ".+"            # Followed by 1 or more characters - which is the docstring for the parameter

--- a/src/tests/test_cases/sections.py
+++ b/src/tests/test_cases/sections.py
@@ -335,6 +335,36 @@ class TestGoogle:  # noqa: D203
 
         """
 
+    @staticmethod
+    @expect("D417: Missing argument descriptions in the docstring "
+            "(argument(s) a, b are missing descriptions in "
+            "'test_missing_docstring' docstring)", arg_count=2)
+    def test_missing_docstring(a, b):  # noqa: D213, D407
+        """Test a valid args section.
+
+        Args:
+            a:
+
+        """
+
+    @staticmethod
+    @expect("D417: Missing argument descriptions in the docstring "
+            "(argument(s) skip, verbose are missing descriptions in "
+            "'test_missing_docstring_another' docstring)", arg_count=2)
+    def test_missing_docstring_another(skip, verbose):  # noqa: D213, D407
+        """Do stuff.
+
+        Args:
+            skip (:attr:`.Skip`):
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                Etiam at tellus a tellus faucibus maximus. Curabitur tellus
+                mauris, semper id vehicula ac, feugiat ut tortor.
+            verbose (bool):
+                If True, print out as much infromation as possible.
+                If False, print out concise "one-liner" information.
+
+        """
+
 
 @expect(_D213)
 @expect("D417: Missing argument descriptions in the docstring "


### PR DESCRIPTION
Currently, due to the way the regex was specified, the regex
matcher was getting thrown off by types that used colons.

This change makes the regex robust to such type and fixes #443

Thanks for submitting a PR!

Please make sure to check for the following items:
- [x] Add unit tests and integration tests where applicable.  
      If you've added an error code or changed an error code behavior,
      you should probably add or change a test case file under `tests/test_cases/` and add 
      it to the list under `tests/test_definitions.py`.  
      If you've added or changed a command line option,
      you should probably add or change a test in `tests/test_integration.py`.
- [ ] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
   
Please don't get discouraged as it may take a while to get a review.
