### PR TITLE
fix: regex to catch inner functions doesn't catch asynchronous ones

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -14,6 +14,7 @@ New Features
 Bug Fixes
 
 * Update convention support documentation (#386, #393)
+* Detect inner asynchronous functions (#467)
 
 5.0.2 - January 8th, 2020
 ---------------------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -14,7 +14,7 @@ New Features
 Bug Fixes
 
 * Update convention support documentation (#386, #393)
-* Detect inner asynchronous functions (#467)
+* Detect inner asynchronous functions for D202 (#467)
 
 5.0.2 - January 8th, 2020
 ---------------------------

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -203,7 +203,7 @@ class ConventionChecker:
                 # class.
                 if not (
                     blanks_after_count == 1 and
-                    re(r"\s+(?:(?:class|def)\s|@)").match(after)
+                    re(r"\s+(?:(?:class|def|async def)\s|@)").match(after)
                 ):
                     yield violations.D202(blanks_after_count)
 

--- a/src/tests/test_cases/functions.py
+++ b/src/tests/test_cases/functions.py
@@ -29,6 +29,15 @@ def func_with_inner_func_after():
     pass
 
 
+def func_with_inner_async_func_after():
+    """Test a function with inner async function after docstring."""
+
+    async def inner():
+        pass
+
+    pass
+
+
 def fake_decorator(decorated):
     """Fake decorator used to test decorated inner func."""
     return decorated
@@ -39,6 +48,16 @@ def func_with_inner_decorated_func_after():
 
     @fake_decorator
     def inner():
+        pass
+
+    pass
+
+
+def func_with_inner_decorated_async_func_after():
+    """Test a function with inner decorated async function after docstring."""
+
+    @fake_decorator
+    async def inner():
         pass
 
     pass


### PR DESCRIPTION
Hello, and thanks for the great tool!

This small PR fixes the case of detecting asynchronous inner functions, for D202 (inner classes and functions require an empty line between the outer function docstring and them). It is a follow-up of #426.

Please make sure to check for the following items:
- [x] Add unit tests and integration tests where applicable.  
- [x] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
