### PR TITLE
Fix handling of dedented continuation lines.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -20,7 +20,7 @@ Bug Fixes
   The bug caused some argument names to go unreported in D417 (#448).
 * Fixed an issue where skipping errors on module level docstring via #noqa
   failed when there where more prior comments (#446).
-* Support backslash-continued parameter descriptions in Numpy-style docstrings
+* Support backslash-continued descriptions in docstrings
   (#472).
 
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -20,6 +20,8 @@ Bug Fixes
   The bug caused some argument names to go unreported in D417 (#448).
 * Fixed an issue where skipping errors on module level docstring via #noqa
   failed when there where more prior comments (#446).
+* Support backslash-continued parameter descriptions in Numpy-style docstrings
+  (#472).
 
 
 5.0.2 - January 8th, 2020

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -278,7 +278,9 @@ class ConventionChecker:
             indent = self._get_docstring_indent(definition, docstring)
             lines = docstring.split('\n')
             if len(lines) > 1:
-                lines = lines[1:]  # First line does not need indent.
+                # First line and line continuations need no indent.
+                lines = [line for i, line in enumerate(lines)
+                         if i and not lines[i-1].endswith('\\')]
                 indents = [leading_space(l) for l in lines if not is_blank(l)]
                 if set(' \t') == set(''.join(indents) + indent):
                     yield violations.D206()
@@ -703,7 +705,9 @@ class ConventionChecker:
         """
         docstring_args = set()
         section_level_indent = leading_space(context.line)
-        content = context.following_lines
+        # Join line continuations, then resplit by line.
+        content = (
+            '\n'.join(context.following_lines).replace('\\\n', '').split('\n'))
         for current_line, next_line in zip(content, content[1:]):
             # All parameter definitions in the Numpy parameters
             # section must be at the same indent level as the section

--- a/src/tests/test_cases/sections.py
+++ b/src/tests/test_cases/sections.py
@@ -389,7 +389,6 @@ class TestGoogle:  # noqa: D203
 @expect("D417: Missing argument descriptions in the docstring "
         "(argument(s) y are missing descriptions in "
         "'test_missing_numpy_args' docstring)")
-@expect("D207: Docstring is under-indented")
 def test_missing_numpy_args(_private_arg=0, x=1, y=2):  # noqa: D406, D407
     """Toggle the gizmo.
 
@@ -405,13 +404,19 @@ of the entire world.
 class TestNumpy:  # noqa: D203
     """Test class."""
 
-    def test_method(self, test, another_test, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
+    def test_method(self, test, another_test, z, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
         """Test a valid args section.
+
+        Some long string with a \
+line continuation.
 
         Parameters
         ----------
         test, another_test
             Some parameters without type.
+        z : some parameter with a very long type description that requires a \
+line continuation.
+            But no further description.
         x, y : int
             Some integer parameters.
 


### PR DESCRIPTION
- Dedent the function definition before parsing it.
- Join continued-lines before attempting to parse the docstring.

Alternative to #441; further improves handling of parameter descriptions with continued lines (which were not handled correctly before).

Thanks for submitting a PR!

Please make sure to check for the following items:
- [X] Add unit tests and integration tests where applicable.  
      If you've added an error code or changed an error code behavior,
      you should probably add or change a test case file under `tests/test_cases/` and add 
      it to the list under `tests/test_definitions.py`.  
      If you've added or changed a command line option,
      you should probably add or change a test in `tests/test_integration.py`.
- [X] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
   
Please don't get discouraged as it may take a while to get a review.
