### PR TITLE
Fix exception cause in config.py

### DIFF
--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -463,7 +463,7 @@ class ConfigurationParser:
                         'known errors: %s', part)
                 expanded_codes.update(codes_to_add)
         except TypeError as e:
-            raise IllegalConfiguration(e)
+            raise IllegalConfiguration(e) from e
 
         return expanded_codes
 


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. I searched this repo, and found just one instance of this mistake.

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 