### PR TITLE
Added updated link to pydocstyle’s documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Run
 Links
 -----
 
-* `Read the full documentation here <http://pydocstyle.org>`_.
+* `Read the full documentation here <http://www.pydocstyle.org/en/5.0.2/>`_.
 
 * `Fork pydocstyle on GitHub <http://github.com/PyCQA/pydocstyle>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Run
 Links
 -----
 
-* `Read the full documentation here <http://www.pydocstyle.org/en/5.0.2/>`_.
+* `Read the full documentation here <http://pydocstyle.org/en/stable/>`_.
 
 * `Fork pydocstyle on GitHub <http://github.com/PyCQA/pydocstyle>`_.
 


### PR DESCRIPTION
Fixes #457
Added new updated link to `pydocstyle’s` documentation (old link is now deprecated)