### PR TITLE
Correctly detect publicity of modules inside directories

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -15,7 +15,7 @@ Bug Fixes
 
 * Update convention support documentation (#386, #393)
 * Detect inner asynchronous functions for D202 (#467)
-* Correctly detect publicity of modules inside directories
+* Correctly detect publicity of modules inside directories (#470)
 
 5.0.2 - January 8th, 2020
 ---------------------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -17,7 +17,7 @@ Bug Fixes
 * Detect inner asynchronous functions for D202 (#467)
 * Fix a bug in parsing Google-style argument description.
   The bug caused some argument names to go unreported in D417 (#448).
-* Correctly detect publicity of modules inside directories (#470).
+* Correctly detect publicity of modules inside directories (#470, #493).
 
 5.0.2 - January 8th, 2020
 ---------------------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -15,6 +15,7 @@ Bug Fixes
 
 * Update convention support documentation (#386, #393)
 * Detect inner asynchronous functions for D202 (#467)
+* Correctly detect publicity of modules inside directories
 
 5.0.2 - January 8th, 2020
 ---------------------------

--- a/src/pydocstyle/parser.py
+++ b/src/pydocstyle/parser.py
@@ -1,5 +1,6 @@
 """Python code parser."""
 
+import os
 import textwrap
 import tokenize as tk
 from itertools import chain, dropwhile
@@ -117,7 +118,8 @@ class Module(Definition):
 
         This helps determine if it requires a docstring.
         """
-        return not self.name.startswith('_') or self.name.startswith('__')
+        module_name = os.path.basename(self.name)
+        return not module_name.startswith('_') or module_name.startswith('__')
 
     def __str__(self):
         return 'at module level'

--- a/src/pydocstyle/parser.py
+++ b/src/pydocstyle/parser.py
@@ -1,11 +1,11 @@
 """Python code parser."""
 
-import os
 import textwrap
 import tokenize as tk
 from itertools import chain, dropwhile
 from re import compile as re
 from io import StringIO
+from pathlib import Path
 
 from .utils import log
 
@@ -118,7 +118,7 @@ class Module(Definition):
 
         This helps determine if it requires a docstring.
         """
-        module_name = os.path.basename(self.name)
+        module_name = Path(self.name).name
         return not module_name.startswith('_') or module_name.startswith('__')
 
     def __str__(self):

--- a/src/tests/parser_test.py
+++ b/src/tests/parser_test.py
@@ -1,6 +1,7 @@
 """Parser tests."""
 
 import io
+import os
 import sys
 import pytest
 import textwrap
@@ -562,18 +563,22 @@ def test_matrix_multiplication_with_decorators(code):
     assert inner_function.decorators[0].name == 'a'
 
 
-def test_module_publicity():
+@pytest.mark.parametrize("parent_path", (
+    os.path.join("some", "directory"),
+    ""
+))
+def test_module_publicity(parent_path):
     """Test that a module that has a single leading underscore is private."""
     parser = Parser()
     code = CodeSnippet("")
 
-    module = parser.parse(code, "filepath")
+    module = parser.parse(code, os.path.join(parent_path, "filepath"))
     assert module.is_public
 
-    module = parser.parse(code, "_filepath")
+    module = parser.parse(code, os.path.join(parent_path, "_filepath"))
     assert not module.is_public
 
-    module = parser.parse(code, "__filepath")
+    module = parser.parse(code, os.path.join(parent_path, "__filepath"))
     assert module.is_public
 
 

--- a/src/tests/parser_test.py
+++ b/src/tests/parser_test.py
@@ -1,10 +1,10 @@
 """Parser tests."""
 
 import io
-import os
 import sys
 import pytest
 import textwrap
+from pathlib import Path
 
 from pydocstyle.parser import Parser, ParseError
 
@@ -564,21 +564,21 @@ def test_matrix_multiplication_with_decorators(code):
 
 
 @pytest.mark.parametrize("parent_path", (
-    os.path.join("some", "directory"),
-    ""
+    Path("some").joinpath("directory"),
+    Path("")
 ))
 def test_module_publicity(parent_path):
     """Test that a module that has a single leading underscore is private."""
     parser = Parser()
     code = CodeSnippet("")
 
-    module = parser.parse(code, os.path.join(parent_path, "filepath"))
+    module = parser.parse(code, str(parent_path.joinpath("filepath")))
     assert module.is_public
 
-    module = parser.parse(code, os.path.join(parent_path, "_filepath"))
+    module = parser.parse(code, str(parent_path.joinpath("_filepath")))
     assert not module.is_public
 
-    module = parser.parse(code, os.path.join(parent_path, "__filepath"))
+    module = parser.parse(code, str(parent_path.joinpath("__filepath")))
     assert module.is_public
 
 


### PR DESCRIPTION
Continuation of PR #470 as @tibdex was taking a little to respond, and their PR relates to issue #493 that I opened.

I branched off @tibdex's work so they get contribution credits for the work they did. Thank you @tibdex!!

@samj1912 @Nurdok Please review. This uses `pathlib` in the `parser_test.py` now.