### PR TITLE
Test on Python 3.9-dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9-dev]
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install tox

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,3 +1,3 @@
 pytest==3.0.2
 pytest-pep8==1.0.6
-mypy==0.730
+mypy==0.782

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = {py35,py36,py37,py38}-{tests,install},docs,install,py36-docs
+envlist = {py35,py36,py37,py38,py39}-{tests,install},docs,install,py36-docs
 
 [testenv]
 download = true


### PR DESCRIPTION
Python 3.9 is out in October, with rc1 now available, and it's strongly recommended to test against it now to make sure libraries work, and also to help test 3.9 itself.

There was an error running mypy:

```
py39 run-test: commands[1] | mypy --config-file=tox.ini src/
src/pydocstyle/utils.py:25: error: syntax error in type comment
Found 1 error in 1 file (checked 35 source files)
ERROR: InvocationError for command /private/tmp/pydocstyle/.tox/py39/bin/mypy --config-file=tox.ini src/ (exited with code 2)
```

This looks like it was fixed in mypy in https://github.com/python/mypy/pull/8716, and released in mypy v0.780. So let's upgrade to use the newest 0.782.

---

Thanks for submitting a PR!

Please make sure to check for the following items:
- [x] Add unit tests and integration tests where applicable.  
      If you've added an error code or changed an error code behavior,
      you should probably add or change a test case file under `tests/test_cases/` and add 
      it to the list under `tests/test_definitions.py`.  
      If you've added or changed a command line option,
      you should probably add or change a test in `tests/test_integration.py`.
- [n/a?] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
   
Please don't get discouraged as it may take a while to get a review.
