### PR TITLE
Enable full `toml` configuration and `pyproject.toml`

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,6 +4,12 @@ Release Notes
 **pydocstyle** version numbers follow the
 `Semantic Versioning <http://semver.org/>`_ specification.
 
+Current Development Version
+---------------------------
+
+New Features
+
+* Enable full toml configuration and pyproject.toml (#534).
 
 6.0.0 - March 18th, 2021
 ---------------------------

--- a/docs/snippets/config.rst
+++ b/docs/snippets/config.rst
@@ -1,6 +1,6 @@
-``pydocstyle`` supports *ini*-like configuration files.
-In order for ``pydocstyle`` to use it, it must be named one of the following
-options, and have a ``[pydocstyle]`` section.
+``pydocstyle`` supports *ini*-like and *toml* configuration files.
+In order for ``pydocstyle`` to use a configuration file automatically, it must
+be named one of the following options.
 
 * ``setup.cfg``
 * ``tox.ini``
@@ -8,11 +8,20 @@ options, and have a ``[pydocstyle]`` section.
 * ``.pydocstyle.ini``
 * ``.pydocstylerc``
 * ``.pydocstylerc.ini``
+* ``pyproject.toml``
 
 When searching for a configuration file, ``pydocstyle`` looks for one of the
-file specified above *in that exact order*. If a configuration file was not
-found, it keeps looking for one up the directory tree until one is found or
-uses the default configuration.
+file specified above *in that exact order*. *ini*-like configuration files must
+have a ``[pydocstyle]`` section while *toml* configuration files must have a
+``[tool.pydocstyle]`` section. If a configuration file was not found,
+``pydocstyle`` keeps looking for one up the directory tree until one is found
+or uses the default configuration.
+
+.. note::
+
+    *toml* configuration file support is only enabled if the ``toml`` python
+    package is installed. You can ensure that this is the case by installing
+    the ``pydocstyle[toml]`` optional dependency.
 
 .. note::
 

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,1 +1,2 @@
 snowballstemmer==1.2.1
+toml==0.10.2

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ version = '6.0.1rc'
 
 requirements = [
     'snowballstemmer',
+    'toml',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,10 @@ version = '6.0.1rc'
 
 requirements = [
     'snowballstemmer',
-    'toml',
 ]
+extra_requirements = {
+    'toml': ['toml'],
+}
 
 
 setup(
@@ -37,6 +39,7 @@ setup(
     package_dir={'': 'src'},
     package_data={'pydocstyle': ['data/*.txt']},
     install_requires=requirements,
+    extras_require=extra_requirements,
     entry_points={
         'console_scripts': [
             'pydocstyle = pydocstyle.cli:main',

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -100,6 +100,11 @@ class TomlParser:
         except KeyError:
             raise NoOptionError(option, section)
 
+        if isinstance(value, dict):
+            raise TypeError(
+                f"Expected {section}.{option} to be an option, not a section."
+            )
+
         # toml should convert types automatically
         # don't manually convert, just check, that the type is correct
         if _conv is not None and not isinstance(value, _conv):
@@ -654,7 +659,7 @@ class ConfigurationParser:
             file.
 
             """
-            if not isinstance(value_str, list):
+            if isinstance(value_str, str):
                 value_str = value_str.split(",")
             return cls._expand_error_codes(
                 {x.strip() for x in value_str} - {""}

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -184,7 +184,7 @@ class ConfigurationParser:
         '.pep257',
     )
 
-    POSSIBLE_SECTION_NAMES = ('pydocstyle', 'pep257')
+    POSSIBLE_SECTION_NAMES = ('pydocstyle', 'pep257', 'tool.pydocstyle')
 
     def __init__(self):
         """Create a configuration parser."""

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -179,6 +179,7 @@ class ConfigurationParser:
         '.pydocstyle.ini',
         '.pydocstylerc',
         '.pydocstylerc.ini',
+        'pyproject.toml',
         # The following is deprecated, but remains for backwards compatibility.
         '.pep257',
     )
@@ -404,7 +405,10 @@ class ConfigurationParser:
         Returns (options, should_inherit).
 
         """
-        parser = RawConfigParser(inline_comment_prefixes=('#', ';'))
+        if path.endswith('.toml'):
+            parser = TomlParser()
+        else:
+            parser = RawConfigParser(inline_comment_prefixes=('#', ';'))
         options = None
         should_inherit = True
 
@@ -527,7 +531,10 @@ class ConfigurationParser:
             path = os.path.dirname(path)
 
         for fn in cls.PROJECT_CONFIG_FILES:
-            config = RawConfigParser(inline_comment_prefixes=('#', ';'))
+            if fn.endswith('.toml'):
+                config = TomlParser()
+            else:
+                config = RawConfigParser(inline_comment_prefixes=('#', ';'))
             full_path = os.path.join(path, fn)
             if config.read(full_path) and cls._get_section_name(config):
                 return full_path

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -653,8 +653,10 @@ class ConfigurationParser:
             file.
 
             """
+            if not isinstance(value_str, list):
+                value_str = value_str.split(",")
             return cls._expand_error_codes(
-                {x.strip() for x in value_str.split(",")} - {""}
+                {x.strip() for x in value_str} - {""}
             )
 
         for opt in optional_set_options:

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -70,7 +70,7 @@ class TomlParser:
             current = reduce(
                 operator.getitem,
                 section.split('.'),
-                self._config,
+                self._config['tool'],
             )
         except KeyError:
             current = None
@@ -190,7 +190,7 @@ class ConfigurationParser:
         '.pep257',
     )
 
-    POSSIBLE_SECTION_NAMES = ('pydocstyle', 'pep257', 'tool.pydocstyle')
+    POSSIBLE_SECTION_NAMES = ('pydocstyle', 'pep257')
 
     def __init__(self):
         """Create a configuration parser."""

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -10,10 +10,13 @@ from configparser import NoOptionError, NoSectionError, RawConfigParser
 from functools import reduce
 from re import compile as re
 
-import toml
-
 from .utils import __version__, log
 from .violations import ErrorRegistry, conventions
+
+try:
+    import toml
+except ImportError:  # pragma: no cover
+    toml = None  # type: ignore
 
 
 def check_initialized(method):
@@ -57,6 +60,13 @@ class TomlParser:
         for filename in filenames:
             try:
                 with open(filename, encoding=encoding) as fp:
+                    if not toml:
+                        log.warning(
+                            "The %s configuration file was ignored, "
+                            "because the `toml` package is not installed.",
+                            filename,
+                        )
+                        continue
                     self._config.update(toml.load(fp))
             except OSError:
                 continue

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -433,7 +433,7 @@ class ConfigurationParser:
             path = os.path.dirname(path)
 
         for fn in cls.PROJECT_CONFIG_FILES:
-            config = RawConfigParser()
+            config = RawConfigParser(inline_comment_prefixes=('#', ';'))
             full_path = os.path.join(path, fn)
             if config.read(full_path) and cls._get_section_name(config):
                 return full_path

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -58,10 +58,11 @@ class SandboxEnv:
         name = self.config_name if name is None else name
         if name.endswith('.toml'):
             def convert_value(val):
-                if isinstance(val, bool):
-                    return repr(val).lower()
-                else:
-                    return repr(val)
+                return (
+                    repr(val).lower()
+                    if isinstance(val, bool)
+                    else repr(val)
+                )
         else:
             def convert_value(val):
                 return val

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -402,8 +402,12 @@ def test_config_path(env):
                 pass
         """))
 
+    # either my_config.ini or my_config.toml
+    config_ext = env.config_name.split('.')[-1]
+    config_name = 'my_config.' + config_ext
+
     env.write_config(ignore='D100')
-    env.write_config(name='my_config', ignore='D103')
+    env.write_config(name=config_name, ignore='D103')
 
     out, err, code = env.invoke()
     assert code == 1
@@ -411,7 +415,7 @@ def test_config_path(env):
     assert 'D103' in out
 
     out, err, code = env.invoke('--config={} -d'
-                                .format(env.get_path('my_config')))
+                                .format(env.get_path(config_name)))
     assert code == 1, out + err
     assert 'D100' in out
     assert 'D103' not in out

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -363,6 +363,31 @@ def test_multiple_lined_config_file(env):
     assert 'D103' not in out
 
 
+@pytest.mark.parametrize(
+    # Don't parametrize over 'tox.ini' since
+    # this test applies only to '.toml' files
+    'env', ['toml'], indirect=True
+)
+def test_accepts_select_error_code_list(env):
+    """Test that .ini files with multi-lined entries are parsed correctly."""
+    with env.open('example.py', 'wt') as example:
+        example.write(textwrap.dedent("""\
+            class Foo(object):
+                "Doc string"
+                def foo():
+                    pass
+        """))
+
+    env.write_config(select=['D100', 'D204', 'D300'])
+
+    out, err, code = env.invoke()
+    assert code == 1
+    assert 'D100' in out
+    assert 'D204' in out
+    assert 'D300' in out
+    assert 'D103' not in out
+
+
 def test_config_path(env):
     """Test that options are correctly loaded from a specific config file.
 
@@ -520,6 +545,21 @@ def test_ignores_whitespace_in_fixed_option_set(env):
     with env.open('example.py', 'wt') as example:
         example.write("class Foo(object):\n    'Doc string'")
     env.write_config(ignore="D100,\n  # comment\n  D300")
+    out, err, code = env.invoke()
+    assert code == 1
+    assert 'D300' not in out
+    assert err == ''
+
+
+@pytest.mark.parametrize(
+    # Don't parametrize over 'tox.ini' since
+    # this test applies only to '.toml' files
+    'env', ['toml'], indirect=True
+)
+def test_accepts_ignore_error_code_list(env):
+    with env.open('example.py', 'wt') as example:
+        example.write("class Foo(object):\n    'Doc string'")
+    env.write_config(ignore=['D100', 'D300'])
     out, err, code = env.invoke()
     assert code == 1
     assert 'D300' not in out

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -137,10 +137,20 @@ def install_package(request):
     )
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.yield_fixture(scope="function", params=['ini', 'toml'])
 def env(request):
     """Add a testing environment to a test method."""
-    with SandboxEnv() as test_env:
+    sandbox_settings = {
+        'ini': {
+            'section_name': 'pydocstyle',
+            'config_name': 'tox.ini',
+        },
+        'toml': {
+            'section_name': 'tool.pydocstyle',
+            'config_name': 'pyproject.toml',
+        },
+    }[request.param]
+    with SandboxEnv(**sandbox_settings) as test_env:
         yield test_env
 
 

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -335,6 +335,11 @@ def test_sectionless_config_file(env):
     assert 'file does not contain a pydocstyle section' not in err
 
 
+@pytest.mark.parametrize(
+    # Don't parametrize over 'pyproject.toml'
+    # since this test applies only to '.ini' files
+    'env', ['ini'], indirect=True
+)
 def test_multiple_lined_config_file(env):
     """Test that .ini files with multi-lined entries are parsed correctly."""
     with env.open('example.py', 'wt') as example:
@@ -506,6 +511,11 @@ def test_wildcard_add_ignore_cli(env):
     assert 'D300' not in out
 
 
+@pytest.mark.parametrize(
+    # Don't parametrize over 'pyproject.toml'
+    # since this test applies only to '.ini' files
+    'env', ['ini'], indirect=True
+)
 def test_ignores_whitespace_in_fixed_option_set(env):
     with env.open('example.py', 'wt') as example:
         example.write("class Foo(object):\n    'Doc string'")

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -59,7 +59,7 @@ class SandboxEnv:
         if name.endswith('.toml'):
             def convert_value(val):
                 if isinstance(val, bool):
-                    return {True: 'true', False: 'false'}[val]
+                    return repr(val).lower()
                 else:
                     return repr(val)
         else:


### PR DESCRIPTION
This PR closes #447.

### Changes

- Fix a small unrelated bug, where inline comments in `.ini` files behaved differently when autodetected by `_get_config_file_in_folder` and when manually specified by `--config`.
- Add `toml` as a package dependency (`setup.py`) and as a pinned runtime dependency (`requirements/runtime.txt`).
- Implement `TomlParser` - a thin wrapper around the `toml` library with minimal API parity with `RawConfigParser`.
- Autodetect `pyproject.toml` configuration
- Autodetect `tool.pydocstyle` section
- Implement error code list support for `toml`. This is so that you can use

  ```toml
  select = [
      "D100",
      # This line is ignored
      "D103",
  ]
  ```
  and not only

  ```toml
  select = "D100,D103"
  ```
- Almost all tests in `test_integration.py` which used the `env` fixture now are run for both `toml` and `ini` versions of the configuration (47 tests).
- 2 tests are only run for `ini` configuration: `test_ignores_whitespace_in_fixed_option_set` and `test_multiple_lined_config_file`. In `toml`, strings must be quoted, so comments and newlines **inside** the strings don't make much sense, which is what these tests are checking. Instead, I've implemented 2 "equivalent" `toml` tests that also check the list support: `test_accepts_ignore_error_code_list` and `test_accepts_select_error_code_list`.

### Please make sure to check for the following items:
- [x] Add unit tests and integration tests where applicable.  
- [ ] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.

There's currently no "Current Development Version" section in `docs/release_notes.rst`. Where should I add the changes?