### PR TITLE
Updating readme to reflect support for Python 3.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ docstring conventions.
 `PEP 257 <http://www.python.org/dev/peps/pep-0257/>`_ out of the box, but it
 should not be considered a reference implementation.
 
-**pydocstyle** supports Python 3.6, 3.7 and 3.8.
+**pydocstyle** supports Python 3.6, 3.7, 3.8 and 3.9.
 
 
 Quick Start


### PR DESCRIPTION
According to the badge on the README Python 3.9 is supported and 3.9 is tested in CI, but it is not listed as being supported in the text of the README so I added it there.
