### PR TITLE
Exempt properties from D401

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -8,9 +8,9 @@ Release Notes
 Current Development Version
 ---------------------------
 
-Bug Fixes
+New Features
 
-* Properties no longer cause D401
+* Add support for `property_decorators` config to ignore  D401
 
 6.1.1 - May 17th, 2021
 ---------------------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -8,6 +8,9 @@ Release Notes
 Current Development Version
 ---------------------------
 
+Bug Fixes
+
+* Properties no longer cause D401
 
 6.1.1 - May 17th, 2021
 ---------------------------

--- a/docs/snippets/config.rst
+++ b/docs/snippets/config.rst
@@ -44,6 +44,7 @@ Available options are:
 * ``match``
 * ``match_dir``
 * ``ignore_decorators``
+* ``property_decorators``
 
 See the :ref:`cli_usage` section for more information.
 

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -500,7 +500,7 @@ class ConventionChecker:
         "Returns the pathname ...".
 
         """
-        if docstring and not function.is_test:
+        if docstring and not function.is_test and not function.is_property:
             stripped = ast.literal_eval(docstring).strip()
             if stripped:
                 first_word = strip_non_alphanumeric(stripped.split()[0])

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -131,8 +131,12 @@ class ConventionChecker:
         source,
         filename,
         ignore_decorators=None,
+        property_decorators=None,
         ignore_inline_noqa=False,
     ):
+        self.property_decorators = (
+            {} if property_decorators is None else property_decorators
+        )
         module = parse(StringIO(source), filename)
         for definition in module:
             for this_check in self.checks:
@@ -500,7 +504,11 @@ class ConventionChecker:
         "Returns the pathname ...".
 
         """
-        if docstring and not function.is_test and not function.is_property:
+        if (
+            docstring
+            and not function.is_test
+            and not function.is_property(self.property_decorators)
+        ):
             stripped = ast.literal_eval(docstring).strip()
             if stripped:
                 first_word = strip_non_alphanumeric(stripped.split()[0])
@@ -1040,6 +1048,7 @@ def check(
     select=None,
     ignore=None,
     ignore_decorators=None,
+    property_decorators=None,
     ignore_inline_noqa=False,
 ):
     """Generate docstring errors that exist in `filenames` iterable.
@@ -1092,7 +1101,11 @@ def check(
             with tk.open(filename) as file:
                 source = file.read()
             for error in ConventionChecker().check_source(
-                source, filename, ignore_decorators, ignore_inline_noqa
+                source,
+                filename,
+                ignore_decorators,
+                property_decorators,
+                ignore_inline_noqa,
             ):
                 code = getattr(error, 'code', None)
                 if code in checked_codes:

--- a/src/pydocstyle/cli.py
+++ b/src/pydocstyle/cli.py
@@ -42,12 +42,14 @@ def run_pydocstyle():
             filename,
             checked_codes,
             ignore_decorators,
+            property_decorators,
         ) in conf.get_files_to_check():
             errors.extend(
                 check(
                     (filename,),
                     select=checked_codes,
                     ignore_decorators=ignore_decorators,
+                    property_decorators=property_decorators,
                 )
             )
     except IllegalConfiguration as error:

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -186,7 +186,7 @@ class ConfigurationParser:
     DEFAULT_MATCH_RE = r'(?!test_).*\.py'
     DEFAULT_MATCH_DIR_RE = r'[^\.].*'
     DEFAULT_IGNORE_DECORATORS_RE = ''
-    DEFAULT_PROPERTY_DECORATORS = "property,cached_property"
+    DEFAULT_PROPERTY_DECORATORS = "property,cached_property,functools.cached_property"
     DEFAULT_CONVENTION = conventions.pep257
 
     PROJECT_CONFIG_FILES = (

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -271,7 +271,7 @@ class ConfigurationParser:
             """Return the `property_decorators` as None or set."""
             return (
                 set(conf.property_decorators.split(","))
-                if conf.proprety_decorators
+                if conf.property_decorators
                 else None
             )
 

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -542,7 +542,7 @@ class ConfigurationParser:
 
         kwargs = dict(checked_codes=checked_codes)
         defaults = {
-            'match': "DEFAULT_MATCH_RE",
+            'match': "MATCH_RE",
             'match_dir': "MATCH_DIR_RE",
             'ignore_decorators': "IGNORE_DECORATORS_RE",
             'property_decorators': "PROPERTY_DECORATORS",

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -186,7 +186,9 @@ class ConfigurationParser:
     DEFAULT_MATCH_RE = r'(?!test_).*\.py'
     DEFAULT_MATCH_DIR_RE = r'[^\.].*'
     DEFAULT_IGNORE_DECORATORS_RE = ''
-    DEFAULT_PROPERTY_DECORATORS = "property,cached_property,functools.cached_property"
+    DEFAULT_PROPERTY_DECORATORS = (
+        "property,cached_property,functools.cached_property"
+    )
     DEFAULT_CONVENTION = conventions.pep257
 
     PROJECT_CONFIG_FILES = (

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -502,7 +502,12 @@ class ConfigurationParser:
         self._set_add_options(error_codes, child_options)
 
         kwargs = dict(checked_codes=error_codes)
-        for key in ('match', 'match_dir', 'ignore_decorators', 'property_decorators'):
+        for key in (
+            'match',
+            'match_dir',
+            'ignore_decorators',
+            'property_decorators',
+        ):
             kwargs[key] = getattr(child_options, key) or getattr(
                 parent_config, key
             )
@@ -536,9 +541,15 @@ class ConfigurationParser:
             checked_codes = cls._get_checked_errors(options)
 
         kwargs = dict(checked_codes=checked_codes)
-        for key in ('match', 'match_dir', 'ignore_decorators', 'property_decorators'):
+        defaults = {
+            'match': "DEFAULT_MATCH_RE",
+            'match_dir': "MATCH_DIR_RE",
+            'ignore_decorators': "IGNORE_DECORATORS_RE",
+            'property_decorators': "PROPERTY_DECORATORS",
+        }
+        for key, default in defaults.items():
             kwargs[key] = (
-                getattr(cls, f'DEFAULT_{key.upper()}_RE')
+                getattr(cls, f"DEFAULT_{default}")
                 if getattr(options, key) is None and use_defaults
                 else getattr(options, key)
             )

--- a/src/pydocstyle/parser.py
+++ b/src/pydocstyle/parser.py
@@ -219,6 +219,14 @@ class Function(Definition):
         return False
 
     @property
+    def is_property(self):
+        """Return True iff the method decorated with property."""
+        for decorator in self.decorators:
+            if "property" in decorator.name:
+                return True
+        return False
+
+    @property
     def is_test(self):
         """Return True if this function is a test function/method.
 

--- a/src/pydocstyle/parser.py
+++ b/src/pydocstyle/parser.py
@@ -213,17 +213,16 @@ class Function(Definition):
     @property
     def is_overload(self):
         """Return True iff the method decorated with overload."""
-        for decorator in self.decorators:
-            if decorator.name == "overload":
-                return True
-        return False
+        return any(
+            decorator.name == "overload" for decorator in self.decorators
+        )
 
-    def is_property(self, decorators):
-        """Return True iff the method decorated with property."""
-        for decorator in self.decorators:
-            if decorator.name in decorators:
-                return True
-        return False
+    def is_property(self, property_decorator_names):
+        """Return True if the method is decorated with any property decorator."""
+        return any(
+            decorator.name in property_decorator_names
+            for decorator in self.decorators
+        )
 
     @property
     def is_test(self):

--- a/src/pydocstyle/parser.py
+++ b/src/pydocstyle/parser.py
@@ -218,11 +218,10 @@ class Function(Definition):
                 return True
         return False
 
-    @property
-    def is_property(self):
+    def is_property(self, decorators):
         """Return True iff the method decorated with property."""
         for decorator in self.decorators:
-            if "property" in decorator.name:
+            if decorator.name in decorators:
                 return True
         return False
 

--- a/src/tests/test_cases/test.py
+++ b/src/tests/test_cases/test.py
@@ -1,5 +1,6 @@
 # No docstring, so we can test D100
-from functools import wraps
+import functools
+from functools import cached_property, wraps
 import os
 from .expected import Expectation
 from typing import overload
@@ -46,6 +47,16 @@ class class_:
     def foo(self):
         """The foo of the thing, which isn't in imperitive mood."""
         return "hello"
+
+    @cached_property
+    def bar(self):
+        """The bar of the thing, which also isn't in imperitive mood."""
+        return "bye"
+
+    @functools.cached_property
+    def foobar(self):
+        """The foobar of the thing; not in imperitive mood."""
+        return "hello again"
 
     @expect('D102: Missing docstring in public method')
     def __new__(self=None):

--- a/src/tests/test_cases/test.py
+++ b/src/tests/test_cases/test.py
@@ -42,6 +42,11 @@ class class_:
            "D418: Function/ Method decorated with @overload"
            " shouldn't contain a docstring")
 
+    @property
+    def foo(self):
+        """The foo of the thing, which isn't in imperitive mood."""
+        return "hello"
+
     @expect('D102: Missing docstring in public method')
     def __new__(self=None):
         pass

--- a/src/tests/test_cases/test.py
+++ b/src/tests/test_cases/test.py
@@ -1,6 +1,5 @@
 # No docstring, so we can test D100
-import functools
-from functools import cached_property, wraps
+from functools import wraps
 import os
 from .expected import Expectation
 from typing import overload
@@ -47,16 +46,6 @@ class class_:
     def foo(self):
         """The foo of the thing, which isn't in imperitive mood."""
         return "hello"
-
-    @cached_property
-    def bar(self):
-        """The bar of the thing, which also isn't in imperitive mood."""
-        return "bye"
-
-    @functools.cached_property
-    def foobar(self):
-        """The foobar of the thing; not in imperitive mood."""
-        return "hello again"
 
     @expect('D102: Missing docstring in public method')
     def __new__(self=None):

--- a/src/tests/test_definitions.py
+++ b/src/tests/test_definitions.py
@@ -38,7 +38,8 @@ def test_complex_file(test_case):
     results = list(check([test_case_file],
                          select=set(ErrorRegistry.get_error_codes()),
                          ignore_decorators=re.compile(
-                             'wraps|ignored_decorator')))
+                             'wraps|ignored_decorator'),
+                         property_decorators="property,cached_property"))
     for error in results:
         assert isinstance(error, Error)
     results = {(e.definition.name, e.message) for e in results}

--- a/src/tests/test_definitions.py
+++ b/src/tests/test_definitions.py
@@ -35,11 +35,14 @@ def test_complex_file(test_case):
     test_case_file = os.path.join(test_case_dir,
                                   'test_cases',
                                   test_case + '.py')
-    results = list(check([test_case_file],
-                         select=set(ErrorRegistry.get_error_codes()),
-                         ignore_decorators=re.compile(
-                             'wraps|ignored_decorator'),
-                         property_decorators="property,cached_property"))
+    results = list(
+        check(
+            [test_case_file],
+            select=set(ErrorRegistry.get_error_codes()),
+            ignore_decorators=re.compile('wraps|ignored_decorator'),
+            property_decorators="property,cached_property,functools.cached_property",
+        )
+    )
     for error in results:
         assert isinstance(error, Error)
     results = {(e.definition.name, e.message) for e in results}

--- a/src/tests/test_definitions.py
+++ b/src/tests/test_definitions.py
@@ -5,6 +5,9 @@ import re
 import pytest
 from pydocstyle.violations import Error, ErrorRegistry
 from pydocstyle.checker import check
+from pydocstyle.config import ConfigurationParser
+
+DEFAULT_PROPERTY_DECORATORS = ConfigurationParser.DEFAULT_PROPERTY_DECORATORS
 
 
 @pytest.mark.parametrize('test_case', [
@@ -40,7 +43,7 @@ def test_complex_file(test_case):
             [test_case_file],
             select=set(ErrorRegistry.get_error_codes()),
             ignore_decorators=re.compile('wraps|ignored_decorator'),
-            property_decorators="property,cached_property,functools.cached_property",
+            property_decorators=DEFAULT_PROPERTY_DECORATORS,
         )
     )
     for error in results:


### PR DESCRIPTION
This addresses issue #531. It excludes any method decorated with a decorator with "property" in the name in order to catch `cached_property` and other custom property types. Maybe there’s a fancier way of doing this, but I don’t know what it is.