### PR TITLE
Fix match option to only consider basename when given a path argument

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -12,6 +12,10 @@ New Features
 
 * Add support for `property_decorators` config to ignore  D401
 
+Bug Fixes
+
+* Fix ``--match`` option to only consider filename when matching full paths (#550).
+
 6.1.1 - May 17th, 2021
 ---------------------------
 

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -288,7 +288,7 @@ class ConfigurationParser:
                     # Skip any dirs that do not match match_dir
                     dirs[:] = [d for d in dirs if match_dir(d)]
 
-                    for filename in filenames:
+                    for filename in map(os.path.basename, filenames):
                         if match(filename):
                             full_path = os.path.join(root, filename)
                             yield (
@@ -302,7 +302,7 @@ class ConfigurationParser:
                 match, _ = _get_matches(config)
                 ignore_decorators = _get_ignore_decorators(config)
                 property_decorators = _get_property_decorators(config)
-                if match(name):
+                if match(os.path.basename(name)):
                     yield (
                         name,
                         list(config.checked_codes),

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -1489,3 +1489,25 @@ def test_comment_with_noqa_plus_docstring_file(env):
     out, _, code = env.invoke()
     assert '' == out
     assert code == 0
+
+
+def test_match_considers_basenames_for_path_args(env):
+    """Test that `match` option only considers basenames for path arguments.
+
+    The test environment consists of a single empty module `test_a.py`. The
+    match option is set to a pattern that ignores test_ prefixed .py filenames.
+    When pydocstyle is invoked with full path to `test_a.py`, we expect it to
+    succeed since match option will match against just the file name and not
+    full path.
+    """
+    # Ignore .py files prefixed with 'test_'
+    env.write_config(select='D100', match='(?!test_).+.py')
+
+    # Create an empty module (violates D100)
+    with env.open('test_a.py', 'wt') as test:
+        test.write('')
+
+    # env.invoke calls pydocstyle with full path to test_a.py
+    out, _, code = env.invoke(target='test_a.py')
+    assert '' == out
+    assert code == 0


### PR DESCRIPTION
Fixes #549.

This uses `os.path.basename` before trying to match against the pattern set in `--match` option. This way, even if full paths to files are passed to `pydocstyle` (by VSCode, for example), only filename part of the path will be matched with the set pattern, thereby eliminating accidental matches with the path. This is also more consistent with how `--match` is documented previously.

Please make sure to check for the following items:
- [x] Add unit tests and integration tests where applicable.  
      If you've added an error code or changed an error code behavior,
      you should probably add or change a test case file under `tests/test_cases/` and add 
      it to the list under `tests/test_definitions.py`.  
      If you've added or changed a command line option,
      you should probably add or change a test in `tests/test_integration.py`.
- [x] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.