### PR TITLE
Add D419: Add and switch to "Docstring is empty" error code

### DIFF
--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -196,12 +196,7 @@ class ConventionChecker:
               with a single underscore.
 
         """
-        if (
-            not docstring
-            and definition.is_public
-            or docstring
-            and is_blank(ast.literal_eval(docstring))
-        ):
+        if not docstring and definition.is_public:
             codes = {
                 Module: violations.D100,
                 Class: violations.D101,
@@ -226,6 +221,18 @@ class ConventionChecker:
                 Package: violations.D104,
             }
             return codes[type(definition)]()
+
+    @check_for(Definition, terminal=True)
+    def check_docstring_empty(self, definition, docstring):
+        """D419: Docstring is empty.
+
+        If the user provided a docstring but it was empty, it is like they never provided one.
+
+        NOTE: This used to report as D10X errors.
+
+        """
+        if docstring and is_blank(ast.literal_eval(docstring)):
+            return violations.D419()
 
     @check_for(Definition)
     def check_one_liners(self, definition, docstring):

--- a/src/pydocstyle/violations.py
+++ b/src/pydocstyle/violations.py
@@ -415,6 +415,10 @@ D418 = D4xx.create_error(
     'D418',
     'Function/ Method decorated with @overload shouldn\'t contain a docstring',
 )
+D419 = D4xx.create_error(
+    'D419',
+    'Docstring is empty',
+)
 
 
 class AttrDict(dict):

--- a/src/tests/test_cases/capitalization.py
+++ b/src/tests/test_cases/capitalization.py
@@ -13,7 +13,7 @@ def not_capitalized():
 
 
 # Make sure empty docstrings don't generate capitalization errors.
-@expect("D103: Missing docstring in public function")
+@expect("D419: Docstring is empty")
 def empty_docstring():
     """"""
 

--- a/src/tests/test_cases/test.py
+++ b/src/tests/test_cases/test.py
@@ -13,7 +13,7 @@ expect('class_', 'D101: Missing docstring in public class')
 
 class class_:
 
-    expect('meta', 'D106: Missing docstring in public nested class')
+    expect('meta', 'D419: Docstring is empty')
 
     class meta:
         """"""
@@ -64,13 +64,13 @@ class class_:
         pass
 
 
-@expect('D103: Missing docstring in public function')
+@expect('D419: Docstring is empty')
 def function():
     """ """
     def ok_since_nested():
         pass
 
-    @expect('D103: Missing docstring in public function')
+    @expect('D419: Docstring is empty')
     def nested():
         ''
 


### PR DESCRIPTION
Reporting D10X errors for empty docstrings is doubly misleading:
1. The docstring _isn't_ missing. It's _empty_.
2. The D10X errors use _public_, but could be reported on private definitions.

Please make sure to check for the following items:
- [x] Add unit tests and integration tests where applicable.  
- [x] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".