### PR TITLE
Fix CI for python 3.10

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,6 @@
 pytest==6.2.5
-mypy==0.782
-black==20.8b1
+mypy==0.930
+black==21.12b0
 isort==5.4.2
+types-toml
+types-setuptools


### PR DESCRIPTION
This commit updates the dependencies for mypy and black to the latest version to fix ast issues with python 3.10

Thanks for submitting a PR!

Please make sure to check for the following items:
- [x] Add unit tests and integration tests where applicable.  
      If you've added an error code or changed an error code behavior,
      you should probably add or change a test case file under `tests/test_cases/` and add 
      it to the list under `tests/test_definitions.py`.  
      If you've added or changed a command line option,
      you should probably add or change a test in `tests/test_integration.py`.
- [x] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
   
Please don't get discouraged as it may take a while to get a review.
