### PR TITLE
Fix issues with `typing.overload`

### DIFF
--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -200,21 +200,20 @@ class ConventionChecker:
 
         """
         if not docstring and definition.is_public:
+            method_violations = None
+            if not definition.is_overload:
+                if definition.is_magic:
+                    method_violations = violations.D105()
+                elif definition.is_init:
+                    method_violations = violations.D107()
+                else:
+                    method_violations = violations.D102()
+
             codes = {
                 Module: violations.D100,
                 Class: violations.D101,
                 NestedClass: violations.D106,
-                Method: lambda: violations.D105()
-                if definition.is_magic
-                else (
-                    violations.D107()
-                    if definition.is_init
-                    else (
-                        violations.D102()
-                        if not definition.is_overload
-                        else None
-                    )
-                ),
+                Method: lambda: method_violations,
                 NestedFunction: violations.D103,
                 Function: (
                     lambda: violations.D103()

--- a/src/pydocstyle/parser.py
+++ b/src/pydocstyle/parser.py
@@ -214,7 +214,7 @@ class Function(Definition):
     def is_overload(self):
         """Return True iff the method decorated with overload."""
         return any(
-            decorator.name == "overload" for decorator in self.decorators
+            decorator.name in ["overload", "typing.overload"] for decorator in self.decorators
         )
 
     def is_property(self, property_decorator_names):


### PR DESCRIPTION
This should fix #525 and also the `def __init__()` overloading which is not explicitly part of that issue.
The fix simply makes use of the existing `is_overload` property also in the case that `definition.is_magic` is true. Previously, this was somehow missed in the inlined if-else construct. I expanded that part to more explicit statements and used a new variable.

I also tried #555 and at least added a match for "typing.overload". But I don't know if pydocstyle is able to infer if a decorator is actually a name bound at import by something like: `from typing import overload as my_overload`.
If not, then I don't see a way to "know" if a given decorator is a `typing.overload`.

If this is ok, I'd add tests as well.

TODO:
- [ ] Add unit tests and integration tests where applicable.  
- [ ] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
