### PR TITLE
Add github action to be able to release on published tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  DEFAULT_PYTHON: 3.9
+
+jobs:
+  release-pypi:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code from Github
+        uses: actions/checkout@v3.0.0
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v3.0.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Install requirements
+        run: |
+          python -m pip install -U pip twine wheel
+          python -m pip install -U "setuptools>=56.0.0"
+      - name: Build distributions
+        run: |
+          python setup.py sdist bdist_wheel
+      - name: Upload to PyPI
+        if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
+        env:
+          TWINE_REPOSITORY: pypi
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          twine upload --verbose dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,6 @@ jobs:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
     environment:
-      name: pypi-dev
-      url: https://test.pypi.org/project/pydocstyle/
-    environment:
       name: pypi-prod
       url: https://pypi.org/project/pydocstyle/
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,10 @@ jobs:
           check-latest: true
       - name: Install requirements
         run: |
-          python -m pip install -U pip twine wheel
-          python -m pip install -U "setuptools>=56.0.0"
+          python -m pip install twine build
       - name: Build distributions
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
       - name: Upload to PyPI
         if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   release-pypi:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
+    environment:
+      name: pypi-prod
     steps:
       - name: Check out code from Github
         uses: actions/checkout@v3.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,10 @@ jobs:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
     environment:
-      name: PyPI
+      name: pypi-dev
+      url: https://test.pypi.org/project/pydocstyle/
+    environment:
+      name: pypi-prod
       url: https://pypi.org/project/pydocstyle/
     steps:
       - name: Check out code from Github

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,22 +6,27 @@ on:
       - published
 
 env:
-  DEFAULT_PYTHON: 3.9
+  DEFAULT_PYTHON: "3.11"
+
+permissions:
+  contents: read
 
 jobs:
   release-pypi:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
     environment:
-      name: pypi-prod
+      name: PyPI
+      url: https://pypi.org/project/pydocstyle/
     steps:
       - name: Check out code from Github
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v3.2.0
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
-        uses: actions/setup-python@v3.0.0
+        uses: actions/setup-python@v4.4.0
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
+          check-latest: true
       - name: Install requirements
         run: |
           python -m pip install -U pip twine wheel


### PR DESCRIPTION
This permit to release on pypi if a value for ``PYPI_API_TOKEN`` is set in github settings. The release is done when a release is created/published in github interface.


Relates to #575 