### PR TITLE
Fix test warnings and improve lint configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -134,7 +134,7 @@ else:
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,8 @@ skip-string-normalization = true
 profile = "black"
 src_paths = ["src/pydocstyle"]
 line_length = 79
+
+[tool.mypy]
+ignore_missing_imports = true
+strict_optional = true
+disallow_incomplete_defs = true

--- a/src/tests/test_integration.py
+++ b/src/tests/test_integration.py
@@ -121,7 +121,7 @@ class SandboxEnv:
         pass
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.fixture(scope="module")
 def install_package(request):
     """Install the package in development mode for the tests.
 
@@ -138,7 +138,7 @@ def install_package(request):
     )
 
 
-@pytest.yield_fixture(scope="function", params=['ini', 'toml'])
+@pytest.fixture(scope="function", params=['ini', 'toml'])
 def env(request):
     """Add a testing environment to a test method."""
     sandbox_settings = {

--- a/tox.ini
+++ b/tox.ini
@@ -66,8 +66,6 @@ skip_install = {[testenv:install]skip_install}
 commands = {[testenv:install]commands}
 
 [pytest]
-pep8ignore =
-    test.py E701 E704
 norecursedirs = docs .tox
 addopts = -rw
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ setenv =
 # To pass arguments to pytest, use `tox [options] -- [pytest posargs]`.
 commands =
     pytest --cache-clear -vv src/tests {posargs}
-    mypy --config-file=tox.ini src/
+    mypy src/
     black --check src/pydocstyle
     isort --check src/pydocstyle
 deps =
@@ -73,8 +73,3 @@ addopts = -rw
 inherit = false
 convention = pep257
 add-select = D404
-
-[mypy]
-ignore_missing_imports = true
-strict_optional = true
-disallow_incomplete_defs = true


### PR DESCRIPTION
Thanks for submitting a PR!

Please make sure to check for the following items:
- [x] Add unit tests and integration tests where applicable.  
      If you've added an error code or changed an error code behavior,
      you should probably add or change a test case file under `tests/test_cases/` and add 
      it to the list under `tests/test_definitions.py`.  
      If you've added or changed a command line option,
      you should probably add or change a test in `tests/test_integration.py`.
- [ ] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
   
Please don't get discouraged as it may take a while to get a review.

---

I ran the tests locally when I noticed some pytest warnings:

```python
.tox/py36-tests/lib/python3.6/site-packages/_pytest/config/__init__.py:1233
  /Users/ahedges/projects/personal/pydocstyle/.tox/py36-tests/lib/python3.6/site-packages/_pytest/config/__init__.py:1233: PytestConfigWarning: Unknown config option: pep8ignore
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

src/tests/test_integration.py:124
  /Users/ahedges/projects/personal/pydocstyle/src/tests/test_integration.py:124: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    @pytest.yield_fixture(scope="module")

src/tests/test_integration.py:141
  /Users/ahedges/projects/personal/pydocstyle/src/tests/test_integration.py:141: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    @pytest.yield_fixture(scope="function", params=['ini', 'toml'])
```

I also saw a Sphinx warning: `WARNING: html_static_path entry '/Users/ahedges/projects/personal/pydocstyle/docs/_static' does not exist`.

I decided to fix these warnings.

I can add release notes if you want, but I don't think they are needed for this.

## Changes

- Fix pytest deprecation warnings by replacing `@pytest.yield_fixture` with `@pytest.fixture`
- Fix pytest unused configuration option warning by removing `pep8ignore`
  - It was used by `pytest-pep8`, which was removed from testing in 0a78a1df7462818e8d405d5f5752e0402baa05c1.
- Fix Sphinx warning by commenting out a line similar to nearby options
  - There hasn't been a `_static` directory since the the line was first added in e8fd68a9cc544aca2040d08ca08edd29e0bd93a4.
- Move mypy config from `tox.ini` to `pyproject.toml`
  - While this isn't strictly necessary, `tox.ini` is not one of the places mypy looks for configuration by default, so running mypy by itself was more annoying. The pinned version of mypy supports configuration in `pyproject.toml`, so it made sense to move it in with the Black and isort configuration.