### PR TITLE
Fix broken CI checks

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,3 +2,6 @@ sphinx_rtd_theme
 # Pinned to 1.6.2 due to a bug in 1.6.3. See GitHub PR #270 for details.
 # TODO: remove this restriction once 1.6.4 or later is released.
 sphinx==1.6.2
+# Pinned to 3.0.3 to prevent an issue with Sphinx
+# See https://github.com/PyCQA/pydocstyle/pull/585
+Jinja2==3.0.3

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,6 +1,6 @@
 pytest==6.2.5
 mypy==0.930
-black==21.12b0
+black==22.3
 isort==5.4.2
 types-toml
 types-setuptools


### PR DESCRIPTION
Thanks for submitting a PR!

Please make sure to check for the following items:
- [ ] Add unit tests and integration tests where applicable.  
      If you've added an error code or changed an error code behavior,
      you should probably add or change a test case file under `tests/test_cases/` and add 
      it to the list under `tests/test_definitions.py`.  
      If you've added or changed a command line option,
      you should probably add or change a test in `tests/test_integration.py`.
- [ ] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
   
Please don't get discouraged as it may take a while to get a review.

---

CI was failing for 03404c81b2ccf57248032af3cdb11f6b4d1e5a63 because of two problems:

- Black was failing from <https://github.com/psf/black/issues/2964>. Updating Black to the latest version fixes it without reformatting any of the code.
- Sphinx was failing from a change in Jinja 3.1.0 that interacted with the old version of Sphinx in this repository. This affected CPython itself earlier this week: <https://bugs.python.org/issue47138>. I'm pinning Jinja2 for now because the Sphinx upgrade will be more difficult.