### PR TITLE
Use tomllib/tomli for reading .toml configs

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -5,6 +5,13 @@ Release Notes
 `Semantic Versioning <http://semver.org/>`_ specification.
 
 
+Current Development Version
+---------------------------
+
+Bug Fixes
+
+* Use tomllib/tomli to correctly read .toml files (#599, #600).
+
 6.2.0 - January 2nd, 2023
 ---------------------------
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -34,15 +34,15 @@ files = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
+name = "tomli"
+version = "1.2.3"
+description = "A lil' TOML parser"
 category = "main"
 optional = true
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = ">=3.6"
 files = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
+    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
 ]
 
 [[package]]
@@ -74,9 +74,9 @@ docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
 testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
 
 [extras]
-toml = ["toml"]
+toml = ["tomli"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.6"
-content-hash = "cd980bd00cd4a5ba9efb4e38007da4c71deab59aac093b9eb1042d2d43505dc6"
+content-hash = "1abb1b7c1fa0c27846501ad1b5d7916eb5ec6e7961eab46ced6887d16428977a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,11 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.6"
 snowballstemmer = ">=2.2.0"
-toml = {version = ">=0.10.2", optional = true}
+tomli = {version = ">=1.2.3", optional = true, python = "<3.11"}
 importlib-metadata = {version = ">=2.0.0,<5.0.0", python = "<3.8"}
 
 [tool.poetry.extras]
-toml = ["toml"]
+toml = ["tomli"]
 
 [tool.poetry.scripts]
 pydocstyle = "pydocstyle.cli:main"

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,3 +1,3 @@
 snowballstemmer>=1.2.1
-toml>=0.10.2
+tomli>=1.2.3; python_version < "3.11"
 importlib-metadata<5.0.0,>=2.0.0; python_version < "3.8"

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,5 +2,4 @@ pytest==6.2.5
 mypy==0.930
 black==22.3
 isort==5.4.2
-types-toml
 types-setuptools

--- a/src/pydocstyle/config.py
+++ b/src/pydocstyle/config.py
@@ -4,6 +4,7 @@ import copy
 import itertools
 import operator
 import os
+import sys
 from collections import namedtuple
 from collections.abc import Set
 from configparser import NoOptionError, NoSectionError, RawConfigParser
@@ -14,10 +15,13 @@ from ._version import __version__
 from .utils import log
 from .violations import ErrorRegistry, conventions
 
-try:
-    import toml
-except ImportError:  # pragma: no cover
-    toml = None  # type: ignore
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomli as tomllib
+    except ImportError:  # pragma: no cover
+        tomllib = None  # type: ignore
 
 
 def check_initialized(method):
@@ -60,15 +64,15 @@ class TomlParser:
         read_ok = []
         for filename in filenames:
             try:
-                with open(filename, encoding=encoding) as fp:
-                    if not toml:
+                with open(filename, "rb") as fp:
+                    if not tomllib:
                         log.warning(
                             "The %s configuration file was ignored, "
-                            "because the `toml` package is not installed.",
+                            "because the `tomli` package is not installed.",
                             filename,
                         )
                         continue
-                    self._config.update(toml.load(fp))
+                    self._config.update(tomllib.load(fp))
             except OSError:
                 continue
             if isinstance(filename, os.PathLike):


### PR DESCRIPTION
Use the built-in `tomllib` module in Python 3.11 and the modern `tomli` package in older Python versions to read .toml configs instead of the unmaintained and broken `toml` package.

Fixes #599
Fixes #600

---
Thanks for submitting a PR!

Please make sure to check for the following items:
- [x] Add unit tests and integration tests where applicable.  (n/a)
      If you've added an error code or changed an error code behavior,
      you should probably add or change a test case file under `tests/test_cases/` and add 
      it to the list under `tests/test_definitions.py`.  
      If you've added or changed a command line option,
      you should probably add or change a test in `tests/test_integration.py`.
- [x] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
   
Please don't get discouraged as it may take a while to get a review.
