### PR TITLE
Fix false positive of google convention missing args descriptions

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -5,6 +5,13 @@ Release Notes
 `Semantic Versioning <http://semver.org/>`_ specification.
 
 
+Current development version
+---------------------------
+
+Bug Fixes
+
+* Fix false positives of D417 in google convention docstrings (#619).
+
 6.2.1 - January 3rd, 2023
 ---------------------------
 

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -862,8 +862,22 @@ class ConventionChecker:
                     y: Ut enim ad minim veniam
         """
         docstring_args = set()
+
         # normalize leading whitespace
-        args_content = dedent("\n".join(context.following_lines)).strip()
+        if context.following_lines:
+            # any lines with shorter indent than the first one should be disregarded
+            first_line = context.following_lines[0]
+            leading_whitespaces = first_line[: -len(first_line.lstrip())]
+
+        args_content = dedent(
+            "\n".join(
+                [
+                    line
+                    for line in context.following_lines
+                    if line.startswith(leading_whitespaces) or line == ""
+                ]
+            )
+        ).strip()
 
         args_sections = []
         for line in args_content.splitlines(keepends=True):

--- a/src/tests/test_cases/sections.py
+++ b/src/tests/test_cases/sections.py
@@ -318,6 +318,17 @@ class TestGoogle:  # noqa: D203
 
         """
 
+    def test_detailed_description(self, test, another_test, _):  # noqa: D213, D407
+        """Test a valid args section.
+
+        Args:
+            test: A parameter.
+            another_test: Another parameter.
+
+        Detailed description.
+
+        """
+
     @expect("D417: Missing argument descriptions in the docstring "
             "(argument(s) test, y, z are missing descriptions in "
             "'test_missing_args' docstring)", arg_count=5)


### PR DESCRIPTION
Closes #618.

- [x] Add unit tests and integration tests where applicable.  
- [x] Add a line to the release notes (docs/release_notes.rst) under "Current Development Version".  
      Make sure to include the PR number after you open and get one.
   
I'm not really happy about this heuristic, but it seems to do the work. It would be cleaner change the splitting of docstring to sections, but I'm afraid its not possible in general case due to `numpy` style having no indent. Anyway, this should fix the problem with `google` style convention and additional lines being considered part of the section.

The solution may not work in mixed tabs/spaces docstring where each line has different whitespace prefix, but I find this to be pretty obscure case (and it's obviously not covered by `pydocstyle` tests anyway).