### PR TITLE
Revert "fix: do not pass file names with pre-commit"

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,3 @@
     entry: pydocstyle
     language: python
     types: [python]
-    pass_file_names: false

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,7 +11,6 @@ Bug Fixes
 
 * Fix decorator parsing for async function. Resolves some false positives
   with async functions and ``overload``. (#577)
-* Obey match rules in pre-commit usage (#610).
 
 6.2.2 - January 3rd, 2023
 ---------------------------


### PR DESCRIPTION
Reverts PyCQA/pydocstyle#610