### PR TITLE
Deprecate pydocstyle in favor of ruff

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,41 @@
 pydocstyle - docstring style checker
 ====================================
 
+======================================
+Deprecation Notice: Pydocstyle
+======================================
+
+.. IMPORTANT: Deprecation Notice
+   :style: alert
+
+.. image:: https://img.shields.io/badge/deprecated-red
+   :target: https://github.com/PyCQA/pydocstyle
+   :alt: Deprecated
+
+The Pydocstyle project is officially deprecated, and it is no longer actively maintained. 
+
+
+
+Ruff: A Modern Alternative
+--------------------------
+
+- **GitHub Repository:** `ruff <https://github.com/astral-sh/ruff>`_
+
+Ruff offers full parity with pydocstyle along with advanced features, better support for the latest Python versions, and ongoing development to ensure a top-notch linting experience. We highly recommend pydocstyle users to switch over to ruff for a seamless transition.
+
+
+A Heartfelt Thank You
+-----------------------
+
+We want to express our heartfelt gratitude to the pydocstyle community, maintainers, and contributors for their support and dedication over the years. Your contributions have been invaluable, and we appreciate the time and effort you've invested in making pydocstyle a valuable tool for the Python community.
+
+Thank you for your support of pydocstyle in the past.
+
+
+
+---------
+
+
 
 .. image:: https://github.com/PyCQA/pydocstyle/workflows/Run%20tests/badge.svg
     :target: https://github.com/PyCQA/pydocstyle/actions?query=workflow%3A%22Run+tests%22+branch%3Amaster


### PR DESCRIPTION
Over the last couple of years, I have been the sole maintainer of pydocstyle. During the last year, we made a call for maintainers but we're unsuccessful in finding appropriate maintainers https://github.com/PyCQA/pydocstyle/issues/575 . Given the emergence of ruff and it's features, it's hard to justify the continued maintenance of pydocstyle. After a conversation with @Nurdok we both agree it's time to archive the project in favor of [ruff](https://github.com/astral-sh/ruff).


We would like to thank the entire pydocstyle community for all the contributions, support and making pydocstyle such a successful project.
